### PR TITLE
Snake_case top_n / min_volume_usd query params

### DIFF
--- a/src/generated.rs
+++ b/src/generated.rs
@@ -1335,7 +1335,7 @@ impl Liquidation {
             parameters.insert("base".to_string(), v.to_string());
         }
         if let Some(v) = options.minVolumeUsd {
-            parameters.insert("minVolumeUsd".to_string(), v.to_string());
+            parameters.insert("min_volume_usd".to_string(), v.to_string());
         }
         if let Some(v) = options.limit {
             parameters.insert("limit".to_string(), v.to_string());
@@ -1350,7 +1350,7 @@ impl Liquidation {
             parameters.insert("window".to_string(), v.to_string());
         }
         if let Some(v) = options.topN {
-            parameters.insert("topN".to_string(), v.to_string());
+            parameters.insert("top_n".to_string(), v.to_string());
         }
         self.client.get("/liquidation/heatmap", Some(parameters))
     }
@@ -1382,7 +1382,7 @@ impl Liquidation {
             parameters.insert("exchange".to_string(), v.to_string());
         }
         if let Some(v) = options.minVolumeUsd {
-            parameters.insert("minVolumeUsd".to_string(), v.to_string());
+            parameters.insert("min_volume_usd".to_string(), v.to_string());
         }
         self.client.get("/liquidation/stats", Some(parameters))
     }
@@ -1811,7 +1811,7 @@ impl OpenInterest {
     pub fn summary(&self, options: OpenInterestSummaryOptions) -> Result<serde_json::Value> {
         let mut parameters = HashMap::new();
         if let Some(v) = options.topN {
-            parameters.insert("topN".to_string(), v.to_string());
+            parameters.insert("top_n".to_string(), v.to_string());
         }
         self.client.get("/open-interest/summary", Some(parameters))
     }


### PR DESCRIPTION
## What changed
Hand-edited `src/generated.rs` (the `datamaxi-codegen` generator is not present in this repo, so per the issue's fallback clause edited directly) so the SDK sends snake_case query-string keys, matching the backend snake_case query-param migration:

- `parameters.insert("minVolumeUsd", ...)` → `"min_volume_usd"` (2 insert sites)
- `parameters.insert("topN", ...)` → `"top_n"` (2 insert sites)

That's the whole change — 4 string literals. Diff stat: `1 file changed, 4 insertions(+), 4 deletions(-)`.

## Scope: wire keys only — public API unchanged
The wire key (the string in `parameters.insert(...)`) is decoupled from the Rust struct field name — the value `v` is read from `options.minVolumeUsd` regardless of the literal. So we get the functional snake_case-on-the-wire fix **without** renaming the public builder methods / struct fields.

The `.minVolumeUsd()` / `.topN()` builders and `minVolumeUsd` / `topN` fields intentionally **stay camelCase** to preserve the SDK's public API — renaming them would be a breaking change for downstream consumers, justified only by cosmetic clippy `non_snake_case` on already-generated code. Those clippy `non_snake_case` warnings therefore remain (pre-existing on generated code).

Not an outage fix — backend dual-read still accepts camelCase; this is canonical alignment of the query string.

## Test plan
- `cargo build` — succeeds (pre-existing unrelated warnings only: error_chain cfg, unused import, and the intentionally-retained `non_snake_case` on the camelCase generated fields/methods).
- `git diff origin/main --stat` — only `src/generated.rs`, 4 lines.
- Grep confirms the 4 insert sites now use `min_volume_usd` / `top_n`; camelCase fields/methods/accessors unchanged.

Closes Bisonai/datamaxi-backend#7399