### PR TITLE
Remove unused deps (api, tungstenite, url) + dead error variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,10 @@ license = "MIT"
 
 [dependencies]
 dotenv = "0.15.0"
-api = "0.2.0"
 error-chain = "0.12.4"
 reqwest = { version = "0.12.7", features = ["blocking", "json"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
-tungstenite = "0.24.0"
-url = "2.5.2"
 
 [dev-dependencies]
 mockito = "1.5.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -131,10 +131,6 @@ error_chain! {
         ReqError(reqwest::Error);
         InvalidHeaderError(reqwest::header::InvalidHeaderValue);
         IoError(std::io::Error);
-        ParseFloatError(std::num::ParseFloatError);
-        UrlParserError(url::ParseError);
         Json(serde_json::Error);
-        Tungstenite(tungstenite::Error);
-        TimestampError(std::time::SystemTimeError);
     }
 }


### PR DESCRIPTION
Closes #11

## Summary
Removed dead-weight crates.io dependencies and the dead `error_chain!` foreign-link variants that referenced them.

**Removed from `Cargo.toml`:**
- `api = "0.2.0"` — unrelated crates.io crate; all `api::` references are the local `crate::api` / `datamaxi::api` module (`src/api.rs`). No external usage.
- `tungstenite = "0.24.0"` — SDK is blocking REST only; referenced solely by the dead `Tungstenite` variant.
- `url = "2.5.2"` — **verdict: removed.** Confirmed unused: only ref was the dead `UrlParserError(url::ParseError)` variant. (Other "url" grep hits are a local `url` String var in `get()` and mockito's `Matcher::UrlEncoded` in tests — neither uses the `url` crate.)

**Removed `foreign_links` variants in `src/api.rs`:**
- `UrlParserError(url::ParseError)`
- `Tungstenite(tungstenite::Error)`
- `ParseFloatError(std::num::ParseFloatError)` — **verdict: removed**, grep-confirmed unused.
- `TimestampError(std::time::SystemTimeError)` — **verdict: removed**, grep-confirmed unused.

No `use` imports needed cleanup (variants used fully-qualified paths). `Cargo.lock` is gitignored/untracked (library crate), so no lockfile change.

## Test plan
- `cargo build` — green (only pre-existing snake_case warnings in `generated.rs`, unrelated).
- `cargo test` — green: 8/8 wire_contract + 5/5 unit + 8 doc-tests pass.