### PR TITLE
Percent-encode query params via reqwest .query()

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -46,36 +46,24 @@ impl Client {
         }
     }
 
-    /// Builds a request string from a set of parameters.
-    fn build_request(parameters: HashMap<String, String>) -> String {
-        parameters
-            .iter()
-            .map(|(key, value)| format!("{}={}", key, value))
-            .collect::<Vec<String>>()
-            .join("&")
-    }
-
     /// Sends a GET request to the specified endpoint with optional parameters.
     pub fn get<T: DeserializeOwned>(
         &self,
         endpoint: &'static str,
         parameters: Option<HashMap<String, String>>,
     ) -> Result<T> {
-        let mut url: String = format!("{}{}", self.base_url, endpoint);
+        let url: String = format!("{}{}", self.base_url, endpoint);
+
+        let mut request = self
+            .inner_client
+            .get(url.as_str())
+            .header("X-DTMX-APIKEY", &self.api_key);
 
         if let Some(p) = parameters {
-            let request = Self::build_request(p);
-
-            if !request.is_empty() {
-                url.push_str(format!("?{}", request).as_str());
-            }
+            request = request.query(&p);
         }
 
-        let client = &self.inner_client;
-        let response = client
-            .get(url.as_str())
-            .header("X-DTMX-APIKEY", &self.api_key)
-            .send()?;
+        let response = request.send()?;
 
         self.handle_response(response)
     }

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -100,6 +100,39 @@ fn cex_candle_sends_required_and_optional_keys() {
     assert!(res.is_ok(), "expected Ok, got {:?}", res);
 }
 
+/// Query-param values containing reserved/non-ASCII characters MUST be
+/// percent-encoded on the wire (issue #10). `Matcher::UrlEncoded` decodes the
+/// incoming query before comparing, so a match proves the raw value was encoded
+/// and round-trips. A pre-fix hand-rolled `k=v` join would emit the raw `&`,
+/// `=`, space and `\u{e9}`, corrupting the query string and failing this match.
+#[test]
+fn query_params_are_percent_encoded() {
+    let mut server = mockito::Server::new();
+
+    // Contains `&`, `=`, a space and a non-ASCII char.
+    let raw_symbol = "A&B=C D\u{e9}";
+
+    let mock = server
+        .mock("GET", "/cex/candle")
+        .match_header("X-DTMX-APIKEY", API_KEY)
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("exchange".into(), "binance".into()),
+            Matcher::UrlEncoded("market".into(), "spot".into()),
+            Matcher::UrlEncoded("symbol".into(), raw_symbol.into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("[]")
+        .expect(1)
+        .create();
+
+    let candle: CexCandle = Datamaxi::new_with_base_url(API_KEY.to_string(), server.url());
+    let res = candle.get("binance", "spot", raw_symbol, CexCandleOptions::new());
+
+    mock.assert();
+    assert!(res.is_ok(), "expected Ok, got {:?}", res);
+}
+
 // --- handle_response status mapping ---------------------------------------
 
 #[allow(clippy::result_large_err)] // crate Error is error_chain-sized; not under test here


### PR DESCRIPTION
Closes #10

## Summary
`Client::get` built the query string by hand (`build_request`: `format!("{}={}", k, v).join("&")`), with no URL-encoding — any value containing `&`, `=`, `+`, space or non-ASCII produced a malformed query string on **every** endpoint (`cex`/`dex` + `generated`).

- Removed `build_request`; route all params through reqwest's `.query(&parameters)`, which percent-encodes keys and values.
- All call sites already go through `Client::get`, so every endpoint is covered with no caller changes.

## Out of scope
The minor `build().unwrap()` panic on client construction (noted in the issue) is **not** fixed here: `Client::new` and the `Datamaxi` trait's `new`/`new_with_base_url` return `Self`, so surfacing the build error would force a `Result` return cascading through every typed builder — too wide for this fix. Left for a follow-up.

## Test plan
- Added `query_params_are_percent_encoded` in `tests/wire_contract.rs`: sends a `symbol` value containing `&`, `=`, space and a non-ASCII char; `Matcher::UrlEncoded` decodes the incoming query, so a match proves the value was percent-encoded and round-trips. Pre-fix code would emit the raw chars and fail.
- `cargo build`, `cargo test` (9 wire tests + doctests), `cargo clippy --all-targets` (0 errors), `cargo fmt --check` all pass.