### PR TITLE
Modernize rust.yml CI: drop actions-rs, pin stable, gate clippy, test job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,46 +12,28 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
           components: clippy
-      - run: cargo clippy --all-targets
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets -- -D warnings
 
   fmt:
     name: format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly
-          override: true
-          profile: minimal
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   test:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all-targets
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-targets
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all-targets

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,14 @@
 //!
 //![MIT License](./LICENSE)
 
+// The archived `error-chain` dependency produces a large `Err` variant
+// (`clippy::result_large_err`) and emits an internal `cfg` that rustc does not
+// recognise (`unexpected_cfgs`). Both are pre-existing and require replacing
+// `error-chain` to fix properly; allow them crate-wide so clippy can gate on
+// genuine warnings. Tracked separately.
+#![allow(clippy::result_large_err)]
+#![allow(unexpected_cfgs)]
+
 /// API definitions and related utilities.
 pub mod api;
 
@@ -201,4 +209,8 @@ pub mod models;
 /// let opts = LiquidationHeatmapOptions::new();
 /// let heatmap = liq.heatmap(opts)?;
 /// ```
+// `generated.rs` is code-generated (DO NOT EDIT); these lints reflect the
+// upstream API's camelCase params and the generator's constructors, so they are
+// suppressed at the module boundary rather than hand-edited in generated output.
+#[allow(non_snake_case, unused_imports, clippy::new_without_default)]
 pub mod generated;


### PR DESCRIPTION
Closes #12

## Summary
Modernizes `.github/workflows/rust.yml` so CI actually gates.

- Drops archived `actions-rs/*` actions; unifies on `dtolnay/rust-toolchain@stable`, `actions/checkout@v4`, `Swatinem/rust-cache@v2` (mirrors `docs.yml`).
- Pins **stable** (was `nightly`) for lint + fmt.
- **Clippy now gates**: `cargo clippy --all-targets -- -D warnings`.
- `test` job runs `cargo test --all-targets` on push + PR (modernizes the pre-existing actions-rs test job; not a new duplicate — #15's harness lives in `tests/wire_contract.rs`).

### Making clippy gating pass (zero warnings)
`-D warnings` only works if warnings are zero. Current warnings, all pre-existing:
- `generated.rs` (code-gen, DO NOT EDIT): `non_snake_case` (upstream camelCase params), `new_without_default`, one stray `unused_imports` → suppressed via `#[allow(...)]` on the `pub mod generated;` boundary so regeneration can't clobber it.
- From archived `error-chain` dep, crate-wide: `clippy::result_large_err` (160-byte `Err` variant) and `unexpected_cfgs` → `#![allow(...)]` in `lib.rs` with a comment; proper fix needs replacing `error-chain` (deferred).

No hand-edits to generated output; no `-D warnings` shipped red.

## Test plan
Locally (worktree):
- `cargo fmt --all -- --check` → clean
- `cargo clippy --all-targets -- -D warnings` → passes (0 warnings)
- `cargo test --all-targets` → 8 passed
CI will now run fmt, clippy (gating), and test on push + PR.