### PR TITLE
Modernize deps: dotenv -> dotenvy (dev-dependency)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-dotenv = "0.15.0"
 error-chain = "0.12.4"
 reqwest = { version = "0.12.7", features = ["blocking", "json"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
 
 [dev-dependencies]
+dotenvy = "0.15.7"
 mockito = "1.5.0"

--- a/examples/cex-candle.rs
+++ b/examples/cex-candle.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 fn main() {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
     let api_key = env::var("DATAMAXI_API_KEY").expect("DATAMAXI_API_KEY not found");
     let candle: datamaxi::cex::Candle = datamaxi::api::Datamaxi::new(api_key);
 

--- a/examples/dex.rs
+++ b/examples/dex.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 fn main() {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
     let api_key = env::var("DATAMAXI_API_KEY").expect("DATAMAXI_API_KEY not found");
     let dex: datamaxi::dex::Dex = datamaxi::api::Datamaxi::new(api_key);
 


### PR DESCRIPTION
## Summary

Part of #14 (dotenvy half; error-chain->thiserror is a separate follow-up PR).

`dotenv 0.15` is unmaintained and was only used by `examples/`. This swaps it for the maintained `dotenvy` fork and relocates it from `[dependencies]` to `[dev-dependencies]` (examples are dev-only).

### What changed
- **Cargo.toml**: removed `dotenv = "0.15.0"` from `[dependencies]`; added `dotenvy = "0.15.7"` under `[dev-dependencies]`.
- **examples/cex-candle.rs**, **examples/dex.rs**: `dotenv::dotenv().ok()` -> `dotenvy::dotenv().ok()` (drop-in API).
- `mockito` left untouched (consumed by the test harness).
- `error-chain` / `src/api.rs` error types untouched.

### Test plan
All run against the worktree manifest:
- `cargo build` - OK
- `cargo build --examples` - OK (examples compile against dotenvy)
- `cargo test` - OK (9 integration + 8 doc tests pass)
- `cargo clippy --all-targets -- -D warnings` - clean

### Notes
- Not "Closes #14": this is only the dotenvy portion. `error-chain -> thiserror` remains a separate PR per the issue (touches the public Error/ErrorKind surface).