### PR TITLE
test: live production integration harness

### DIFF
--- a/tests/live.rs
+++ b/tests/live.rs
@@ -1,0 +1,98 @@
+//! Live integration tests against the real DataMaxi+ production API.
+//!
+//! These exercise the full stack over the wire: request construction, auth
+//! header, real HTTP, and `handle_response` decoding of a genuine 200 body.
+//! Unlike `wire_contract.rs` (offline `mockito`), they catch drift between the
+//! SDK and the live API — e.g. a renamed field, a moved path, or a wire-key
+//! regression that only manifests against production.
+//!
+//! Gated on an API key in the environment (`DTMX_API_KEY`, or
+//! `DATAMAXI_API_KEY`). When absent, each test prints a SKIP line and returns
+//! Ok, so `cargo test` stays green offline and in CI (which has no key). Run
+//! locally with the key present to exercise them:
+//!
+//! ```shell
+//! DTMX_API_KEY=... cargo test --test live
+//! ```
+
+use datamaxi::api::Datamaxi;
+use datamaxi::generated::{CexCandle, CexCandleOptions, Liquidation, LiquidationHeatmapOptions};
+
+/// Resolve the API key from the environment, preferring `DTMX_API_KEY` and
+/// falling back to `DATAMAXI_API_KEY`. Empty values are treated as absent.
+fn api_key() -> Option<String> {
+    ["DTMX_API_KEY", "DATAMAXI_API_KEY"]
+        .into_iter()
+        .filter_map(|k| std::env::var(k).ok())
+        .find(|v| !v.trim().is_empty())
+}
+
+/// Fetch the key or print a SKIP line and bail out of the test as a pass.
+macro_rules! key_or_skip {
+    ($test:literal) => {
+        match api_key() {
+            Some(k) => k,
+            None => {
+                eprintln!("SKIP {}: set DTMX_API_KEY to run live tests", $test);
+                return;
+            }
+        }
+    };
+}
+
+/// `/cex/candle/exchanges` returns a non-empty list including a well-known
+/// exchange. Locks the path, auth, and top-level array shape against prod.
+#[test]
+fn live_cex_candle_exchanges() {
+    let key = key_or_skip!("live_cex_candle_exchanges");
+    let candle: CexCandle = Datamaxi::new(key);
+
+    let v = candle
+        .exchanges("spot")
+        .expect("live /cex/candle/exchanges request failed");
+
+    let arr = v.as_array().expect("expected a JSON array of exchanges");
+    assert!(!arr.is_empty(), "exchange list should not be empty");
+    assert!(
+        arr.iter().any(|e| e.as_str() == Some("binance")),
+        "expected 'binance' in exchange list, got {v}"
+    );
+}
+
+/// `/cex/candle` returns an object carrying a `data` array. Locks the primary
+/// candle endpoint and its response envelope against prod.
+#[test]
+fn live_cex_candle_get() {
+    let key = key_or_skip!("live_cex_candle_get");
+    let candle: CexCandle = Datamaxi::new(key);
+
+    let opts = CexCandleOptions::new().interval("1h");
+    let v = candle
+        .get("binance", "spot", "BTC-USDT", opts)
+        .expect("live /cex/candle request failed");
+
+    let data = v
+        .get("data")
+        .and_then(|d| d.as_array())
+        .expect("expected a `data` array in the candle response");
+    assert!(!data.is_empty(), "candle `data` should not be empty");
+}
+
+/// `/liquidation/heatmap` returns an object with a `tokens` array. Also
+/// exercises the `top_n` snake_case wire key over the real API (the PR #8
+/// regression surface).
+#[test]
+fn live_liquidation_heatmap() {
+    let key = key_or_skip!("live_liquidation_heatmap");
+    let liq: Liquidation = Datamaxi::new(key);
+
+    let opts = LiquidationHeatmapOptions::new().window("1h").topN(3);
+    let v = liq
+        .heatmap(opts)
+        .expect("live /liquidation/heatmap request failed");
+
+    assert!(
+        v.get("tokens").and_then(|t| t.as_array()).is_some(),
+        "expected a `tokens` array in the heatmap response, got {v}"
+    );
+}


### PR DESCRIPTION
## Summary
Adds `tests/live.rs` — integration tests that hit the **real** DataMaxi+ production API over the wire, complementing the offline `mockito` tests in `wire_contract.rs`. Catches SDK↔API drift (renamed fields, moved paths, wire-key regressions) that offline mocks can't.

Covers via `generated`:
- `/cex/candle/exchanges` — non-empty list incl. `binance`
- `/cex/candle` — response carries a `data` array
- `/liquidation/heatmap` — response carries `tokens` (also exercises the `top_n` snake_case wire key, the PR #8 regression surface)

Gated on `DTMX_API_KEY` (falls back to `DATAMAXI_API_KEY`); when absent each test prints `SKIP` and returns Ok, so offline `cargo test` and CI (no key) stay green. Run live with `DTMX_API_KEY=... cargo test --test live`.

This is the **baseline harness** for the `generated.rs` unification effort (#13): every subsequent PR in that series runs unit + live tests.

## Tests
- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo test` — offline: 9 wire + 8 doc-tests ✓
- `cargo test --test live` with prod key — **3/3 pass** ✓

## Notes
First in a stacked series (small PRs) preparing the SDK to converge on `generated`. No source changes; test-only.