### PR TITLE
refactor!: error-chain → thiserror (breaking, 0.4.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "datamaxi"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 readme = "README.md"
 license = "MIT"
 
 [dependencies]
-error-chain = "0.12.4"
 reqwest = { version = "0.12.7", features = ["blocking", "json"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
+thiserror = "2.0.11"
 
 [dev-dependencies]
 dotenvy = "0.15.7"

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,9 +1,9 @@
-use error_chain::error_chain;
 use reqwest::blocking::Response;
 use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::io::Read;
+use thiserror::Error;
 
 const BASE_URL: &str = "https://api.datamaxiplus.com/api/v1";
 
@@ -75,50 +75,46 @@ impl Client {
             StatusCode::INTERNAL_SERVER_ERROR => {
                 let mut response_text = String::new();
                 response.take(1000).read_to_string(&mut response_text)?;
-                Err(ErrorKind::InternalServerError(response_text).into())
+                Err(Error::InternalServerError(response_text))
             }
-            StatusCode::UNAUTHORIZED => Err(ErrorKind::Unauthorized.into()),
+            StatusCode::UNAUTHORIZED => Err(Error::Unauthorized),
             StatusCode::BAD_REQUEST => {
                 let mut response_text = String::new();
                 response.take(1000).read_to_string(&mut response_text)?;
-                Err(ErrorKind::BadRequest(response_text).into())
+                Err(Error::BadRequest(response_text))
             }
-            status => Err(ErrorKind::UnexpectedStatusCode(status.as_u16()).into()),
+            status => Err(Error::UnexpectedStatusCode(status.as_u16())),
         }
     }
 }
 
-error_chain! {
-    errors {
-        /// Represents an error that occurs when a request to the API returns a bad request status.
-        BadRequest(msg: String) {
-            description("Bad request")
-            display("Bad request: {}", msg)
-        }
+/// A specialized [`Result`](std::result::Result) type for Datamaxi+ API calls.
+pub type Result<T> = std::result::Result<T, Error>;
 
-        /// Represents an error that occurs when a request to the API returns an unauthorized status.
-        Unauthorized {
-            description("Unauthorized")
-            display("Unauthorized")
-        }
+/// Errors returned by the Datamaxi+ API client.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// The API returned a `400 Bad Request`; the payload carries the server message.
+    #[error("Bad request: {0}")]
+    BadRequest(String),
 
-        /// Represents an error that occurs when a request to the API returns an internal server error status.
-        InternalServerError(msg: String) {
-            description("Internal server error")
-            display("Internal server error: {}", msg)
-        }
+    /// The API returned a `401 Unauthorized` (missing or invalid API key).
+    #[error("Unauthorized")]
+    Unauthorized,
 
-        /// Represents an error that occurs when a request to the API returns an unexpected status code.
-        UnexpectedStatusCode(status: u16) {
-            description("Unexpected status code")
-            display("Received unexpected status code: {}", status)
-        }
-     }
+    /// The API returned a `500 Internal Server Error`; the payload carries the server message.
+    #[error("Internal server error: {0}")]
+    InternalServerError(String),
 
-    foreign_links {
-        ReqError(reqwest::Error);
-        InvalidHeaderError(reqwest::header::InvalidHeaderValue);
-        IoError(std::io::Error);
-        Json(serde_json::Error);
-    }
+    /// The API returned a status code the client does not specifically handle.
+    #[error("Received unexpected status code: {0}")]
+    UnexpectedStatusCode(u16),
+
+    /// The underlying HTTP request failed, or the response body could not be decoded.
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+
+    /// Reading the response body failed.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,14 +102,6 @@
 //!
 //![MIT License](./LICENSE)
 
-// The archived `error-chain` dependency produces a large `Err` variant
-// (`clippy::result_large_err`) and emits an internal `cfg` that rustc does not
-// recognise (`unexpected_cfgs`). Both are pre-existing and require replacing
-// `error-chain` to fix properly; allow them crate-wide so clippy can gate on
-// genuine warnings. Tracked separately.
-#![allow(clippy::result_large_err)]
-#![allow(unexpected_cfgs)]
-
 /// API definitions and related utilities.
 pub mod api;
 

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -1,0 +1,98 @@
+//! Live integration tests against the real DataMaxi+ production API.
+//!
+//! These exercise the full stack over the wire: request construction, auth
+//! header, real HTTP, and `handle_response` decoding of a genuine 200 body.
+//! Unlike `wire_contract.rs` (offline `mockito`), they catch drift between the
+//! SDK and the live API — e.g. a renamed field, a moved path, or a wire-key
+//! regression that only manifests against production.
+//!
+//! Gated on an API key in the environment (`DTMX_API_KEY`, or
+//! `DATAMAXI_API_KEY`). When absent, each test prints a SKIP line and returns
+//! Ok, so `cargo test` stays green offline and in CI (which has no key). Run
+//! locally with the key present to exercise them:
+//!
+//! ```shell
+//! DTMX_API_KEY=... cargo test --test live
+//! ```
+
+use datamaxi::api::Datamaxi;
+use datamaxi::generated::{CexCandle, CexCandleOptions, Liquidation, LiquidationHeatmapOptions};
+
+/// Resolve the API key from the environment, preferring `DTMX_API_KEY` and
+/// falling back to `DATAMAXI_API_KEY`. Empty values are treated as absent.
+fn api_key() -> Option<String> {
+    ["DTMX_API_KEY", "DATAMAXI_API_KEY"]
+        .into_iter()
+        .filter_map(|k| std::env::var(k).ok())
+        .find(|v| !v.trim().is_empty())
+}
+
+/// Fetch the key or print a SKIP line and bail out of the test as a pass.
+macro_rules! key_or_skip {
+    ($test:literal) => {
+        match api_key() {
+            Some(k) => k,
+            None => {
+                eprintln!("SKIP {}: set DTMX_API_KEY to run live tests", $test);
+                return;
+            }
+        }
+    };
+}
+
+/// `/cex/candle/exchanges` returns a non-empty list including a well-known
+/// exchange. Locks the path, auth, and top-level array shape against prod.
+#[test]
+fn live_cex_candle_exchanges() {
+    let key = key_or_skip!("live_cex_candle_exchanges");
+    let candle: CexCandle = Datamaxi::new(key);
+
+    let v = candle
+        .exchanges("spot")
+        .expect("live /cex/candle/exchanges request failed");
+
+    let arr = v.as_array().expect("expected a JSON array of exchanges");
+    assert!(!arr.is_empty(), "exchange list should not be empty");
+    assert!(
+        arr.iter().any(|e| e.as_str() == Some("binance")),
+        "expected 'binance' in exchange list, got {v}"
+    );
+}
+
+/// `/cex/candle` returns an object carrying a `data` array. Locks the primary
+/// candle endpoint and its response envelope against prod.
+#[test]
+fn live_cex_candle_get() {
+    let key = key_or_skip!("live_cex_candle_get");
+    let candle: CexCandle = Datamaxi::new(key);
+
+    let opts = CexCandleOptions::new().interval("1h");
+    let v = candle
+        .get("binance", "spot", "BTC-USDT", opts)
+        .expect("live /cex/candle request failed");
+
+    let data = v
+        .get("data")
+        .and_then(|d| d.as_array())
+        .expect("expected a `data` array in the candle response");
+    assert!(!data.is_empty(), "candle `data` should not be empty");
+}
+
+/// `/liquidation/heatmap` returns an object with a `tokens` array. Also
+/// exercises the `top_n` snake_case wire key over the real API (the PR #8
+/// regression surface).
+#[test]
+fn live_liquidation_heatmap() {
+    let key = key_or_skip!("live_liquidation_heatmap");
+    let liq: Liquidation = Datamaxi::new(key);
+
+    let opts = LiquidationHeatmapOptions::new().window("1h").topN(3);
+    let v = liq
+        .heatmap(opts)
+        .expect("live /liquidation/heatmap request failed");
+
+    assert!(
+        v.get("tokens").and_then(|t| t.as_array()).is_some(),
+        "expected a `tokens` array in the heatmap response, got {v}"
+    );
+}

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -10,7 +10,7 @@
 //! snake_case (`top_n`, `min_volume_usd`). The query-key assertions below fail
 //! if a future codegen regen reintroduces that bug.
 
-use datamaxi::api::{Datamaxi, ErrorKind};
+use datamaxi::api::{Datamaxi, Error};
 use datamaxi::generated::{
     CexCandle, CexCandleOptions, Liquidation, LiquidationHeatmapOptions, LiquidationStatsOptions,
 };
@@ -135,7 +135,6 @@ fn query_params_are_percent_encoded() {
 
 // --- handle_response status mapping ---------------------------------------
 
-#[allow(clippy::result_large_err)] // crate Error is error_chain-sized; not under test here
 fn call_with_status(status: usize, body: &str) -> datamaxi::api::Result<serde_json::Value> {
     let mut server = mockito::Server::new();
     let _mock = server
@@ -158,7 +157,7 @@ fn status_200_maps_to_ok() {
 fn status_400_maps_to_bad_request() {
     let err = call_with_status(400, "bad input").expect_err("400 should be Err");
     assert!(
-        matches!(err.kind(), ErrorKind::BadRequest(_)),
+        matches!(err, Error::BadRequest(_)),
         "400 should map to BadRequest, got {:?}",
         err
     );
@@ -168,7 +167,7 @@ fn status_400_maps_to_bad_request() {
 fn status_401_maps_to_unauthorized() {
     let err = call_with_status(401, "").expect_err("401 should be Err");
     assert!(
-        matches!(err.kind(), ErrorKind::Unauthorized),
+        matches!(err, Error::Unauthorized),
         "401 should map to Unauthorized, got {:?}",
         err
     );
@@ -178,7 +177,7 @@ fn status_401_maps_to_unauthorized() {
 fn status_500_maps_to_internal_server_error() {
     let err = call_with_status(500, "boom").expect_err("500 should be Err");
     assert!(
-        matches!(err.kind(), ErrorKind::InternalServerError(_)),
+        matches!(err, Error::InternalServerError(_)),
         "500 should map to InternalServerError, got {:?}",
         err
     );
@@ -188,7 +187,7 @@ fn status_500_maps_to_internal_server_error() {
 fn status_404_maps_to_unexpected_status_code() {
     let err = call_with_status(404, "nope").expect_err("404 should be Err");
     assert!(
-        matches!(err.kind(), ErrorKind::UnexpectedStatusCode(404)),
+        matches!(err, Error::UnexpectedStatusCode(404)),
         "404 should map to UnexpectedStatusCode(404), got {:?}",
         err
     );


### PR DESCRIPTION
## Summary
Replaces the **archived** `error-chain` crate with idiomatic `thiserror`. Addresses the long-standing note in `lib.rs` about `error-chain` forcing two crate-wide lint-allows.

**BREAKING** (hence `0.3.3` → `0.4.0`, minor bump per 0.x semver): the public error type changes from error-chain's `Error`/`ErrorKind` pair to a single flat enum `datamaxi::api::Error`. Downstream code that matched `err.kind()` against `ErrorKind::…` now matches the error value directly:

```rust
// before
matches!(err.kind(), ErrorKind::BadRequest(_))
// after
matches!(err, Error::BadRequest(_))
```

Status-mapped variants (`BadRequest`, `Unauthorized`, `InternalServerError`, `UnexpectedStatusCode`) keep the same meaning and `Display` strings; transport/decoding errors fold into `Error::Http(reqwest::Error)` and `Error::Io` via `#[from]`.

## Changes
- `api.rs`: `error_chain!` block → `#[derive(thiserror::Error)]` enum + `pub type Result`.
- `lib.rs`: **remove** `#![allow(clippy::result_large_err)]` and `#![allow(unexpected_cfgs)]` — both existed only to paper over error-chain. New enum is small; clippy passes without them.
- `Cargo.toml`: drop `error-chain`, add `thiserror = 2`, bump version.
- `tests/wire_contract.rs`: `ErrorKind` → `Error`; drop the stale large-err allow.
- `generated.rs` untouched — it imports `crate::api::Result`, whose path is unchanged.

## Tests
- `cargo build` / `fmt --check` / `clippy --all-targets -D warnings` ✓ (no result_large_err warning)
- `cargo test` — 9 wire + 8 doc ✓
- `cargo test --test live` (prod key) — **3/3 pass** ✓

## Notes
Stacked on #22 (base `test/live-integration-harness`). Part of the small-PR series prepping the SDK to converge on `generated` (#13).