### PR TITLE
feat: ClientBuilder (timeout, User-Agent, env key) + drop unwrap panic

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -3,9 +3,33 @@ use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::io::Read;
+use std::time::Duration;
 use thiserror::Error;
 
 const BASE_URL: &str = "https://api.datamaxiplus.com/api/v1";
+
+/// Default per-request timeout, matching the Python SDK's default.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Environment variable consulted for the API key when one is not passed explicitly.
+const API_KEY_ENV: &str = "DATAMAXI_API_KEY";
+
+/// The `User-Agent` sent with every request, e.g. `datamaxi-rust/0.4.0`.
+fn user_agent() -> String {
+    concat!("datamaxi-rust/", env!("CARGO_PKG_VERSION")).to_string()
+}
+
+/// Build the underlying blocking HTTP client with our defaults (timeout,
+/// `User-Agent`, unbounded idle pool). Falls back to a default client if the
+/// builder fails, so client construction is infallible and never panics.
+fn build_inner_client(timeout: Duration) -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
+        .pool_idle_timeout(None)
+        .timeout(timeout)
+        .user_agent(user_agent())
+        .build()
+        .unwrap_or_else(|_| reqwest::blocking::Client::new())
+}
 
 /// A trait that defines the required methods for interacting with the Datamaxi+ API.
 pub trait Datamaxi {
@@ -33,16 +57,27 @@ pub struct Client {
     inner_client: reqwest::blocking::Client,
 }
 
+impl std::fmt::Debug for Client {
+    /// Redacts the API key so it never leaks into logs or error output.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("api_key", &"<redacted>")
+            .finish_non_exhaustive()
+    }
+}
+
 impl Client {
     /// Creates a new instance of the `Client` struct with the provided configuration.
+    ///
+    /// Uses the default timeout ([`DEFAULT_TIMEOUT`]). For more control over
+    /// timeout or reading the API key from the environment, use
+    /// [`ClientBuilder`].
     pub fn new(config: Config) -> Self {
         Client {
             base_url: config.base_url.unwrap_or(BASE_URL.to_string()),
             api_key: config.api_key,
-            inner_client: reqwest::blocking::Client::builder()
-                .pool_idle_timeout(None)
-                .build()
-                .unwrap(),
+            inner_client: build_inner_client(DEFAULT_TIMEOUT),
         }
     }
 
@@ -88,12 +123,99 @@ impl Client {
     }
 }
 
+/// Builder for a [`Client`], giving control over the API key source, base URL,
+/// and request timeout.
+///
+/// The API key may be provided explicitly via [`api_key`](ClientBuilder::api_key)
+/// or, if omitted, is read from the `DATAMAXI_API_KEY` environment variable at
+/// [`build`](ClientBuilder::build) time.
+///
+/// # Example
+/// ```no_run
+/// use datamaxi::api::ClientBuilder;
+/// use std::time::Duration;
+///
+/// // Explicit key + custom timeout.
+/// let client = ClientBuilder::new()
+///     .api_key("my_api_key")
+///     .timeout(Duration::from_secs(30))
+///     .build()
+///     .expect("api key provided");
+///
+/// // Key taken from the DATAMAXI_API_KEY environment variable.
+/// let client = ClientBuilder::new().build();
+/// ```
+#[derive(Debug, Clone)]
+pub struct ClientBuilder {
+    base_url: Option<String>,
+    api_key: Option<String>,
+    timeout: Duration,
+}
+
+impl ClientBuilder {
+    /// Creates a new builder with default settings (default timeout, key read
+    /// from the environment on `build`).
+    pub fn new() -> Self {
+        ClientBuilder {
+            base_url: None,
+            api_key: None,
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+
+    /// Sets the API key explicitly, overriding the `DATAMAXI_API_KEY` environment variable.
+    pub fn api_key(mut self, api_key: impl Into<String>) -> Self {
+        self.api_key = Some(api_key.into());
+        self
+    }
+
+    /// Overrides the base URL (defaults to the production API).
+    pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = Some(base_url.into());
+        self
+    }
+
+    /// Sets the per-request timeout (defaults to 10 seconds).
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Builds the [`Client`].
+    ///
+    /// Resolves the API key from the explicit value or the `DATAMAXI_API_KEY`
+    /// environment variable, returning [`Error::MissingApiKey`] if neither is set.
+    pub fn build(self) -> Result<Client> {
+        let api_key = self
+            .api_key
+            .or_else(|| std::env::var(API_KEY_ENV).ok())
+            .filter(|key| !key.trim().is_empty())
+            .ok_or(Error::MissingApiKey)?;
+
+        Ok(Client {
+            base_url: self.base_url.unwrap_or_else(|| BASE_URL.to_string()),
+            api_key,
+            inner_client: build_inner_client(self.timeout),
+        })
+    }
+}
+
+impl Default for ClientBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A specialized [`Result`](std::result::Result) type for Datamaxi+ API calls.
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Errors returned by the Datamaxi+ API client.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// No API key was provided explicitly and `DATAMAXI_API_KEY` is unset or empty.
+    #[error("missing API key: pass it to ClientBuilder::api_key or set DATAMAXI_API_KEY")]
+    MissingApiKey,
+
     /// The API returned a `400 Bad Request`; the payload carries the server message.
     #[error("Bad request: {0}")]
     BadRequest(String),

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -10,7 +10,7 @@
 //! snake_case (`top_n`, `min_volume_usd`). The query-key assertions below fail
 //! if a future codegen regen reintroduces that bug.
 
-use datamaxi::api::{Datamaxi, Error};
+use datamaxi::api::{ClientBuilder, Datamaxi, Error};
 use datamaxi::generated::{
     CexCandle, CexCandleOptions, Liquidation, LiquidationHeatmapOptions, LiquidationStatsOptions,
 };
@@ -189,6 +189,55 @@ fn status_404_maps_to_unexpected_status_code() {
     assert!(
         matches!(err, Error::UnexpectedStatusCode(404)),
         "404 should map to UnexpectedStatusCode(404), got {:?}",
+        err
+    );
+}
+
+// --- ClientBuilder ---------------------------------------------------------
+
+/// A `Client` built via `ClientBuilder` sends the `datamaxi-rust/<ver>`
+/// User-Agent and the auth header, and routes requests through the same path.
+#[test]
+fn client_builder_sets_user_agent_and_auth() {
+    let mut server = mockito::Server::new();
+
+    let mock = server
+        .mock("GET", "/cex/candle/exchanges")
+        .match_header("X-DTMX-APIKEY", API_KEY)
+        .match_header(
+            "user-agent",
+            Matcher::Regex(r"^datamaxi-rust/\d+\.\d+\.\d+".to_string()),
+        )
+        .match_query(Matcher::UrlEncoded("market".into(), "spot".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("[]")
+        .expect(1)
+        .create();
+
+    let client = ClientBuilder::new()
+        .api_key(API_KEY)
+        .base_url(server.url())
+        .build()
+        .expect("explicit api key should build");
+    let candle = CexCandle { client };
+    let res = candle.exchanges("spot");
+
+    mock.assert();
+    assert!(res.is_ok(), "expected Ok, got {:?}", res);
+}
+
+/// With no explicit key and `DATAMAXI_API_KEY` unset, `build` fails with
+/// `MissingApiKey` rather than silently constructing an unauthenticated client.
+#[test]
+fn client_builder_without_key_errors() {
+    std::env::remove_var("DATAMAXI_API_KEY");
+    let err = ClientBuilder::new()
+        .build()
+        .expect_err("no key should fail to build");
+    assert!(
+        matches!(err, Error::MissingApiKey),
+        "expected MissingApiKey, got {:?}",
         err
     );
 }


### PR DESCRIPTION
## Summary
Hardens client construction toward production readiness (closing gaps vs the Python SDK). `generated.rs` untouched.

- **`ClientBuilder`** — explicit `api_key(...)` or fallback to `DATAMAXI_API_KEY` env var; `Error::MissingApiKey` if neither set. Configurable `timeout` (default **10s**, matching Python) and `base_url`.
- **User-Agent** `datamaxi-rust/<version>` on every request.
- **No panic** — `Client::new` no longer `.unwrap()`s the reqwest builder.
- **Redacting `Debug`** for `Client` — API key printed as `<redacted>`.

## Tests
- `fmt` / `clippy --all-targets -D warnings` ✓
- `cargo test` — 11 wire + 8 doc ✓
- `cargo test --test live` (prod key) — **3/3 pass** ✓

## Notes
Re-opened replacement for #24 (closed by a stacked-squash-merge conflict; content identical, cherry-picked onto merged main). Part of the small-PR series prepping convergence on `generated` (#13).