### PR TITLE
refactor: deprecate hand-written cex module (Closes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,19 @@ Set `DATAMAXI_API_KEY` to avoid passing the key inline.
 ### CEX Candle
 
 ```rust
-let api_key = "my_api_key".to_string();
-let candle: datamaxi::cex::Candle = datamaxi::api::Datamaxi::new(api_key);
+use datamaxi::api::Datamaxi;
+use datamaxi::generated::{CexCandle, CexCandleOptions, CexCandleSymbolsOptions};
 
-// Supported exchanges and symbols
+let api_key = "my_api_key".to_string();
+let candle: CexCandle = Datamaxi::new(api_key);
+
+// Supported exchanges, symbols and intervals
 candle.exchanges("spot");
-let symbols_options = datamaxi::cex::SymbolsOptions::new();
-candle.symbols("binance", symbols_options);
+candle.symbols(CexCandleSymbolsOptions::new().exchange("binance"));
 candle.intervals();
 
-// Fetch candle data
-let candle_options = datamaxi::cex::CandleOptions::new();
-candle.get("binance", "ETH-USDT", candle_options);
+// Fetch candle data (exchange, market, symbol)
+candle.get("binance", "spot", "ETH-USDT", CexCandleOptions::new());
 ```
 
 See [`examples/`](./examples/) for runnable examples.

--- a/examples/cex-candle.rs
+++ b/examples/cex-candle.rs
@@ -1,41 +1,35 @@
+use datamaxi::api::Datamaxi;
+use datamaxi::generated::{CexCandle, CexCandleOptions, CexCandleSymbolsOptions};
 use std::env;
 
 fn main() {
     dotenvy::dotenv().ok();
     let api_key = env::var("DATAMAXI_API_KEY").expect("DATAMAXI_API_KEY not found");
-    let candle: datamaxi::cex::Candle = datamaxi::api::Datamaxi::new(api_key);
+    let candle: CexCandle = Datamaxi::new(api_key);
 
     // CEX Candle Exchanges
     match candle.exchanges("futures") {
-        Ok(answer) => println!("{:?}", answer),
+        Ok(answer) => println!("{}", answer),
         Err(e) => println!("Error: {}", e),
     }
 
     // CEX Candle Symbols
-    let symbols_options = datamaxi::cex::SymbolsOptions::new();
-    let symbols_response = candle.symbols("binance", symbols_options);
-    match symbols_response {
-        Ok(answer) => match serde_json::to_string(&answer) {
-            Ok(json) => println!("{}", json),
-            Err(e) => println!("Error: {}", e),
-        },
+    let symbols_options = CexCandleSymbolsOptions::new().exchange("binance");
+    match candle.symbols(symbols_options) {
+        Ok(answer) => println!("{}", answer),
         Err(e) => println!("Error: {}", e),
     }
 
     // CEX Candle Intervals
     match candle.intervals() {
-        Ok(answer) => println!("{:?}", answer),
+        Ok(answer) => println!("{}", answer),
         Err(e) => println!("Error: {}", e),
     }
 
     // CEX Candle Data
-    let candle_options = datamaxi::cex::CandleOptions::new();
-    let candle_response = candle.get("binance", "ETH-USDT", candle_options);
-    match candle_response {
-        Ok(answer) => match serde_json::to_string(&answer) {
-            Ok(json) => println!("{}", json),
-            Err(e) => println!("Error: {}", e),
-        },
+    let candle_options = CexCandleOptions::new();
+    match candle.get("binance", "spot", "ETH-USDT", candle_options) {
+        Ok(answer) => println!("{}", answer),
         Err(e) => println!("Error: {}", e),
     }
 }

--- a/src/cex.rs
+++ b/src/cex.rs
@@ -1,9 +1,18 @@
+// This hand-written module is deprecated in favour of `crate::generated::CexCandle`.
+// `allow(deprecated)` silences the deprecation warnings for the module's *own*
+// references to `Candle`; external users still get the warning when they name it.
+#![allow(deprecated)]
+
 use crate::api::{Client, Config, Datamaxi, Result};
 pub use crate::models::{CandleOptions, SymbolsOptions};
 use crate::models::{CandleResponse, SymbolsResponse};
 use std::collections::HashMap;
 
 /// Provides methods for retrieving CEX candle data and related information.
+#[deprecated(
+    since = "0.4.0",
+    note = "use datamaxi::generated::CexCandle instead; this hand-written module will be removed in a future release"
+)]
 #[derive(Clone)]
 pub struct Candle {
     pub client: Client,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,23 +31,19 @@
 //!
 //! ### CEX Candle
 //!
-//! ```rust
-//! let api_key = "my_api_key".to_string();
-//! let candle: datamaxi::cex::Candle = datamaxi::api::Datamaxi::new(api_key);
+//! ```no_run
+//! use datamaxi::api::Datamaxi;
+//! use datamaxi::generated::{CexCandle, CexCandleOptions, CexCandleSymbolsOptions};
 //!
-//! // Fetch supported exchanges for CEX candle data
-//! candle.exchanges("spot");
+//! let candle: CexCandle = Datamaxi::new("my_api_key".to_string());
 //!
-//! // Fetch supported symbols for CEX candle data
-//! let symbols_options = datamaxi::cex::SymbolsOptions::new();
-//! candle.symbols("binance", symbols_options);
-//!
-//! // Fetch supported intervals for CEX candle data
-//! candle.intervals();
+//! // Supported exchanges, symbols and intervals
+//! let _ = candle.exchanges("spot");
+//! let _ = candle.symbols(CexCandleSymbolsOptions::new().exchange("binance"));
+//! let _ = candle.intervals();
 //!
 //! // Fetch CEX candle data
-//! let candle_options = datamaxi::cex::CandleOptions::new();
-//! candle.get("binance", "ETH-USDT", candle_options);
+//! let _ = candle.get("binance", "spot", "BTC-USDT", CexCandleOptions::new());
 //! ```
 //!
 //! ## Links
@@ -67,44 +63,12 @@
 /// API definitions and related utilities.
 pub mod api;
 
-/// CEX-related data fetcher and data structures.
+/// **Deprecated** hand-written CEX candle surface.
 ///
-/// This module provides functionality related to centralized exchange (CEX) data.
-/// It includes data structures and methods for retrieving candle data, as well as information about supported exchanges, symbols and intervals.
-///
-/// # Usage
-///
-/// The `Candle` struct is the primary interface for interacting with the CEX data.
-/// It provides methods for retrieving data with optional parameters to filter and sort the results.
-///
-/// ## Example
-///
-/// ```rust
-/// let config = datamaxi::api::Config {
-///     base_url: None,
-///     api_key: "my_api_key".to_string(),
-/// };
-/// let client = datamaxi::api::Client::new(config);
-/// let candle = datamaxi::cex::Candle { client: client.clone() };
-///
-/// // Retrieve supported exchanges
-/// let exchanges = candle.exchanges("spot");
-///
-/// // Retrieve supported intervals
-/// let intervals = candle.intervals();
-///
-/// // Retrieve supported Binance symbols
-/// let symbols_options = datamaxi::cex::SymbolsOptions::new();
-/// let symbols = candle.symbols("binance", symbols_options);
-///
-/// // Retrieve candle data
-/// let candle_options = datamaxi::cex::CandleOptions::new().interval("1h").market("spot");
-/// let candle_data = candle.get("binance", "BTC-USDT", candle_options);
-/// ```
-///
-/// # Error Handling
-///
-/// All methods return a `Result` type, which should be handled appropriately to manage potential errors.
+/// Superseded by [`crate::generated::CexCandle`], which is generated from the
+/// API spec and stays in sync with it. This module is kept only for backward
+/// compatibility and will be removed in a future release; new code should use
+/// `generated::CexCandle`.
 pub mod cex;
 
 /// Data models representing API responses and optional parameters.


### PR DESCRIPTION
## Summary
Converges on `generated` by deprecating the last hand-written module, `cex` (DEX already removed in #26). **Closes #13.**

- `#[deprecated(since = "0.4.0", note = "use datamaxi::generated::CexCandle instead")]` on `cex::Candle`. A module-local `#![allow(deprecated)]` keeps the crate's own build warning-free while **external** users get the deprecation warning on use.
- Ported to `generated::CexCandle`: `examples/cex-candle.rs`, `README.md`, and the crate-level + module docs. Note the arg-order change — `get(exchange, market, symbol, opts)` (market is now a positional arg, not an option).
- `cex` module doc rewritten as a deprecation notice pointing at `generated`.

## Why
The hand-written `cex` surface isn't regenerated by `datamaxi-codegen`, so it silently rots. It already has: its `models.rs` response types drifted from prod (`o/h/l/c/v` are **numbers** live but typed `String` here; `d` is an int typed `String`) — `cex::Candle::get` would fail to deserialize today. `generated::CexCandle` returns `serde_json::Value` and stays in sync with the spec.

## Tests
- `build` / `fmt` / `clippy --all-targets -D warnings` ✓
- `cargo test` — 11 wire + 4 doc (docs now use `generated`) ✓
- `cargo test --test live` (prod key) — **3/3 pass** ✓

## Follow-up
Deleting `cex` + `models.rs` entirely is a future major bump (per #13). Part of the small-PR series prepping the SDK to unify on `generated` like `datamaxi-python`.