### PR TITLE
docs: bump LICENSE copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Bisonai
+Copyright (c) 2026 Bisonai
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Closes #32

Bump MIT LICENSE copyright year from 2024 to 2026. Only `LICENSE` line 3 contained a stale copyright year; no other 2024 copyright strings in repo.

Test plan: docs-only, no build needed.