### PR TITLE
fix!: Option<T> for nullable response fields (0.9.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datamaxi"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 readme = "README.md"
 license = "MIT"

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -676,7 +676,7 @@ pub struct ListingsHistoricalView {
     pub base: String,
     pub deposit_at: i64,
     pub exchange: String,
-    pub network: String,
+    pub network: Option<String>,
     pub trade_at: i64,
     pub url: String,
 }
@@ -851,7 +851,7 @@ pub struct PremiumDetail {
     /// specifies +2% volume depth from source exchange
     pub sbd2p: f64,
     /// for amm source ticker, amm source chain
-    pub sc: String,
+    pub sc: Option<String>,
     /// specifies the source exchange name
     pub se: String,
     /// source funding rate
@@ -881,7 +881,7 @@ pub struct PremiumDetail {
     /// specifies the latest price of the source exchange in requested currency
     pub sp: f64,
     /// for amm source ticker, amm pool address
-    pub spa: String,
+    pub spa: Option<String>,
     /// specifies the price difference percentage of the source exchange in the last 15m
     pub spdp15m: f64,
     /// specifies the price difference percentage of the source exchange in the last 1h
@@ -913,7 +913,7 @@ pub struct PremiumDetail {
     /// target bid depth within -2% quote
     pub tbdf: f64,
     /// for amm target ticker, amm target chain
-    pub tc: String,
+    pub tc: Option<String>,
     /// specifies the target exchange name
     pub te: String,
     /// target funding rate
@@ -940,7 +940,7 @@ pub struct PremiumDetail {
     /// specifies the latest price of the target exchange
     pub tp: f64,
     /// for amm target ticker, amm pool address
-    pub tpa: String,
+    pub tpa: Option<String>,
     /// specifies the price difference percentage of the target exchange in the last 15m
     pub tpdp15m: f64,
     /// specifies the price difference percentage of the target exchange in the last 1h
@@ -1011,7 +1011,7 @@ pub struct TelegramChannelsView {
     pub channel_title: String,
     /// specifies the creation time of the channel
     #[serde(rename = "createdAt")]
-    pub created_at: i64,
+    pub created_at: Option<i64>,
     /// specifies the channel description
     pub description: String,
     /// specifies the channel link

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -317,10 +317,11 @@ fn live_listings_historical() {
             !resp.data.is_empty(),
             "listings historical `data` should not be empty"
         ),
-        // Known bug (codegen#55 / backend#7943): `network` is nullable on the
-        // wire but typed as non-optional `String` in `ListingsHistoricalView`.
+        // `network` (String) is now Option; but a timestamp i64 field
+        // (announced_at/deposit_at/trade_at) is also null on the wire for
+        // not-yet-listed tokens. Tracked for a further nullability pass.
         Err(Error::Http(e)) if e.is_decode() => {
-            eprintln!("KNOWN NULL-DECODE /listings/historical `network`: {e}");
+            eprintln!("KNOWN NULL-DECODE /listings/historical (null i64 timestamp): {e}");
         }
         Err(e) => panic!("live /listings/historical request failed: {e}"),
     }
@@ -433,11 +434,11 @@ fn live_premium_get() {
 
     match premium.get(PremiumOptions::new().limit(10)) {
         Ok(resp) => assert!(!resp.data.is_empty(), "premium `data` should not be empty"),
-        // Known bug (codegen#55 / backend#7943): `PremiumDetail.tc` (and
-        // siblings like `sc`/`spa`/`tpa`) are nullable on the wire but typed
-        // as non-optional `String`.
+        // `sc`/`tc`/`spa`/`tpa` (String) are now Option; but `PremiumDetail`
+        // also has conditionally-present numeric (f64) fields that are null
+        // depending on market type. Tracked for a further nullability pass.
         Err(Error::Http(e)) if e.is_decode() => {
-            eprintln!("KNOWN NULL-DECODE /premium `detail.tc`: {e}");
+            eprintln!("KNOWN NULL-DECODE /premium (null f64 field): {e}");
         }
         Err(e) => panic!("live /premium request failed: {e}"),
     }
@@ -450,18 +451,13 @@ fn live_telegram_channels() {
     let key = key_or_skip!("live_telegram_channels");
     let tg: Telegram = Datamaxi::new(key);
 
-    match tg.channels(TelegramChannelsOptions::new()) {
-        Ok(resp) => assert!(
-            !resp.data.is_empty(),
-            "telegram channels `data` should not be empty"
-        ),
-        // Known bug (codegen#55 / backend#7943): `createdAt` is nullable on
-        // the wire but typed as non-optional `i64` in `TelegramChannelsView`.
-        Err(Error::Http(e)) if e.is_decode() => {
-            eprintln!("KNOWN NULL-DECODE /telegram/channels `createdAt`: {e}");
-        }
-        Err(e) => panic!("live /telegram/channels request failed: {e}"),
-    }
+    let resp = tg
+        .channels(TelegramChannelsOptions::new())
+        .expect("live /telegram/channels request failed");
+    assert!(
+        !resp.data.is_empty(),
+        "telegram channels `data` should not be empty"
+    );
 }
 
 /// `/telegram/messages` returns a non-empty `data` array with default


### PR DESCRIPTION
## Summary

Closes the nullability loop opened by the live-integration validation. With **codegen#56** (honor `nullable` → `Option`) and **backend#7944** (mark 6 fields `nullable: true`) merged, this regenerates `src/generated.rs` so those fields are now `Option<T>`:

- `ListingsHistoricalView.network` → `Option<String>`
- `TelegramChannelsView.created_at` → `Option<i64>`
- `PremiumDetail.sc` / `tc` / `spa` / `tpa` → `Option<String>`

The `generated.rs` diff is exactly those 6 lines. Verified live against production: **25/25 live tests pass**, `wire_contract` 14/14, clippy/fmt clean.

- `tests/live.rs`: `telegram_channels` restored to a proper assertion (its only null field was `created_at`).
- **Breaking** (`0.8.0` → `0.9.0`): 6 response fields change to `Option<T>`.

## Known follow-up
Running the full live suite surfaced *further* nullable fields on two endpoints (each fix reveals the next — the expected long tail):
- `/listings/historical` — a null i64 timestamp (announced_at/deposit_at/trade_at) for not-yet-listed tokens
- `/premium` — conditionally-present f64 numerics that are null by market type

Those two live tests stay tolerant here; a follow-up issue tracks marking the remaining fields nullable in the backend spec. The scheduled live CI (#37) will keep surfacing any others.