### PR TITLE
feat!: async-first client + optional blocking feature (0.10.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,21 @@
 [package]
 name = "datamaxi"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 readme = "README.md"
 license = "MIT"
 
 [dependencies]
-reqwest = { version = "0.12.7", features = ["blocking", "json"] }
+reqwest = { version = "0.12.7", features = ["json"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
 thiserror = "2.0.11"
 
+[features]
+default = []
+blocking = ["reqwest/blocking"]
+
 [dev-dependencies]
 dotenvy = "0.15.7"
 mockito = "1.5.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Fetch both historical and real-time cryptocurrency data using the [DataMaxi+ API
 ```toml
 [dependencies]
 datamaxi = { git = "https://github.com/bisonai/datamaxi-rust.git" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+The client is **async** by default and needs an async runtime (e.g. `tokio`).
+For a synchronous client, enable the `blocking` feature and use the mirrored
+wrappers under `datamaxi::generated::blocking`:
+
+```toml
+[dependencies]
+datamaxi = { git = "https://github.com/bisonai/datamaxi-rust.git", features = ["blocking"] }
 ```
 
 ## Configuration
@@ -40,17 +50,22 @@ let api_key = "my_api_key".to_string();
 let candle: CexCandle = Datamaxi::new(api_key);
 
 // Supported exchanges, symbols and intervals
-candle.exchanges(CexCandleExchangesMarket::Spot);
-candle.symbols("binance", CexCandleSymbolsOptions::new());
-candle.intervals();
+candle.exchanges(CexCandleExchangesMarket::Spot).await?;
+candle.symbols("binance", CexCandleSymbolsOptions::new()).await?;
+candle.intervals().await?;
 
 // Fetch candle data (exchange, symbol); market is an option
-candle.get(
-    "binance",
-    "ETH-USDT",
-    CexCandleOptions::new().market(CexCandleMarket::Spot),
-);
+candle
+    .get(
+        "binance",
+        "ETH-USDT",
+        CexCandleOptions::new().market(CexCandleMarket::Spot),
+    )
+    .await?;
 ```
+
+With the `blocking` feature the same calls are synchronous (no `.await`), via
+`datamaxi::generated::blocking::CexCandle` and `datamaxi::api::blocking`.
 
 Data endpoints deserialize into typed response structs generated from the API
 spec: object responses into a struct (e.g. `candle.get(..)` → `CexCandleResponse`)

--- a/examples/cex-candle.rs
+++ b/examples/cex-candle.rs
@@ -4,33 +4,34 @@ use datamaxi::generated::{
 };
 use std::env;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     dotenvy::dotenv().ok();
     let api_key = env::var("DATAMAXI_API_KEY").expect("DATAMAXI_API_KEY not found");
     let candle: CexCandle = Datamaxi::new(api_key);
 
     // CEX Candle Exchanges
-    match candle.exchanges(CexCandleExchangesMarket::Futures) {
+    match candle.exchanges(CexCandleExchangesMarket::Futures).await {
         Ok(answer) => println!("{:#?}", answer),
         Err(e) => println!("Error: {}", e),
     }
 
     // CEX Candle Symbols
     let symbols_options = CexCandleSymbolsOptions::new();
-    match candle.symbols("binance", symbols_options) {
+    match candle.symbols("binance", symbols_options).await {
         Ok(answer) => println!("{:#?}", answer),
         Err(e) => println!("Error: {}", e),
     }
 
     // CEX Candle Intervals
-    match candle.intervals() {
+    match candle.intervals().await {
         Ok(answer) => println!("{:#?}", answer),
         Err(e) => println!("Error: {}", e),
     }
 
     // CEX Candle Data — `get` returns the typed `CexCandleResponse`.
     let candle_options = CexCandleOptions::new().market(CexCandleMarket::Spot);
-    match candle.get("binance", "ETH-USDT", candle_options) {
+    match candle.get("binance", "ETH-USDT", candle_options).await {
         Ok(answer) => println!("{:#?}", answer),
         Err(e) => println!("Error: {}", e),
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,6 @@
-use reqwest::blocking::Response;
 use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
-use std::io::Read;
 use std::time::Duration;
 use thiserror::Error;
 
@@ -23,16 +21,16 @@ fn user_agent() -> String {
     concat!("datamaxi-rust/", env!("CARGO_PKG_VERSION")).to_string()
 }
 
-/// Build the underlying blocking HTTP client with our defaults (timeout,
-/// `User-Agent`, unbounded idle pool). Falls back to a default client if the
-/// builder fails, so client construction is infallible and never panics.
-fn build_inner_client(timeout: Duration) -> reqwest::blocking::Client {
-    reqwest::blocking::Client::builder()
-        .pool_idle_timeout(None)
-        .timeout(timeout)
-        .user_agent(user_agent())
-        .build()
-        .unwrap_or_else(|_| reqwest::blocking::Client::new())
+/// Truncate a server error body to at most 1000 bytes, on a UTF-8 char boundary.
+fn truncate_body(mut s: String) -> String {
+    if s.len() > 1000 {
+        let mut end = 1000;
+        while !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        s.truncate(end);
+    }
+    s
 }
 
 /// A trait that defines the required methods for interacting with the Datamaxi+ API.
@@ -53,12 +51,27 @@ pub struct Config {
     pub api_key: String,
 }
 
-/// The client for interacting with the Datamaxi+ API.
+/// Build the underlying async HTTP client with our defaults (timeout,
+/// `User-Agent`, unbounded idle pool). Falls back to a default client if the
+/// builder fails, so client construction is infallible and never panics.
+fn build_inner_client(timeout: Duration) -> reqwest::Client {
+    reqwest::Client::builder()
+        .pool_idle_timeout(None)
+        .timeout(timeout)
+        .user_agent(user_agent())
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
+
+/// The async client for interacting with the Datamaxi+ API.
+///
+/// This is the default surface. For a synchronous client, enable the
+/// `blocking` feature and use [`blocking::Client`].
 #[derive(Clone)]
 pub struct Client {
     base_url: String,
     api_key: String,
-    inner_client: reqwest::blocking::Client,
+    inner_client: reqwest::Client,
 }
 
 impl std::fmt::Debug for Client {
@@ -86,9 +99,9 @@ impl Client {
     }
 
     /// Sends a GET request to the specified endpoint with optional parameters.
-    pub fn get<T: DeserializeOwned>(
+    pub async fn get<T: DeserializeOwned>(
         &self,
-        endpoint: &'static str,
+        endpoint: &str,
         parameters: Option<HashMap<String, String>>,
     ) -> Result<T> {
         let url: String = format!("{}{}", self.base_url, endpoint);
@@ -102,28 +115,26 @@ impl Client {
             request = request.query(&p);
         }
 
-        let response = request.send()?;
+        let response = request.send().await?;
 
-        self.handle_response(response)
+        handle_response(response).await
     }
+}
 
-    /// Processes the response from the API and returns the result.
-    fn handle_response<T: DeserializeOwned>(&self, response: Response) -> Result<T> {
-        match response.status() {
-            StatusCode::OK => Ok(response.json::<T>()?),
-            StatusCode::INTERNAL_SERVER_ERROR => {
-                let mut response_text = String::new();
-                response.take(1000).read_to_string(&mut response_text)?;
-                Err(Error::InternalServerError(response_text))
-            }
-            StatusCode::UNAUTHORIZED => Err(Error::Unauthorized),
-            StatusCode::BAD_REQUEST => {
-                let mut response_text = String::new();
-                response.take(1000).read_to_string(&mut response_text)?;
-                Err(Error::BadRequest(response_text))
-            }
-            status => Err(Error::UnexpectedStatusCode(status.as_u16())),
+/// Processes an async response from the API and returns the result.
+async fn handle_response<T: DeserializeOwned>(response: reqwest::Response) -> Result<T> {
+    match response.status() {
+        StatusCode::OK => Ok(response.json::<T>().await?),
+        StatusCode::INTERNAL_SERVER_ERROR => {
+            let body = response.text().await.unwrap_or_default();
+            Err(Error::InternalServerError(truncate_body(body)))
         }
+        StatusCode::UNAUTHORIZED => Err(Error::Unauthorized),
+        StatusCode::BAD_REQUEST => {
+            let body = response.text().await.unwrap_or_default();
+            Err(Error::BadRequest(truncate_body(body)))
+        }
+        status => Err(Error::UnexpectedStatusCode(status.as_u16())),
     }
 }
 
@@ -244,4 +255,163 @@ pub enum Error {
     /// Reading the response body failed.
     #[error(transparent)]
     Io(#[from] std::io::Error),
+}
+
+/// Synchronous client surface, enabled by the `blocking` feature.
+///
+/// Mirrors the async [`Client`] with the same status-to-[`Error`] mapping, for
+/// scripts, notebooks, and other callers that don't run an async runtime. The
+/// generated endpoint wrappers under [`crate::generated::blocking`] use this.
+#[cfg(feature = "blocking")]
+pub mod blocking {
+    use super::{
+        truncate_body, user_agent, Config, Error, Result, API_KEY_ENV, BASE_URL, DEFAULT_TIMEOUT,
+    };
+    use reqwest::blocking::Response;
+    use reqwest::StatusCode;
+    use serde::de::DeserializeOwned;
+    use std::collections::HashMap;
+    use std::io::Read;
+    use std::time::Duration;
+
+    /// Build the underlying blocking HTTP client with our defaults. Falls back
+    /// to a default client if the builder fails, so construction never panics.
+    fn build_inner_client(timeout: Duration) -> reqwest::blocking::Client {
+        reqwest::blocking::Client::builder()
+            .pool_idle_timeout(None)
+            .timeout(timeout)
+            .user_agent(user_agent())
+            .build()
+            .unwrap_or_else(|_| reqwest::blocking::Client::new())
+    }
+
+    /// The blocking client for interacting with the Datamaxi+ API.
+    #[derive(Clone)]
+    pub struct Client {
+        base_url: String,
+        api_key: String,
+        inner_client: reqwest::blocking::Client,
+    }
+
+    impl std::fmt::Debug for Client {
+        /// Redacts the API key so it never leaks into logs or error output.
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("Client")
+                .field("base_url", &self.base_url)
+                .field("api_key", &"<redacted>")
+                .finish_non_exhaustive()
+        }
+    }
+
+    impl Client {
+        /// Creates a new blocking `Client` with the provided configuration and
+        /// the default timeout. For more control, use [`ClientBuilder`].
+        pub fn new(config: Config) -> Self {
+            Client {
+                base_url: config.base_url.unwrap_or(BASE_URL.to_string()),
+                api_key: config.api_key,
+                inner_client: build_inner_client(DEFAULT_TIMEOUT),
+            }
+        }
+
+        /// Sends a GET request to the specified endpoint with optional parameters.
+        pub fn get<T: DeserializeOwned>(
+            &self,
+            endpoint: &str,
+            parameters: Option<HashMap<String, String>>,
+        ) -> Result<T> {
+            let url: String = format!("{}{}", self.base_url, endpoint);
+
+            let mut request = self
+                .inner_client
+                .get(url.as_str())
+                .header("X-DTMX-APIKEY", &self.api_key);
+
+            if let Some(p) = parameters {
+                request = request.query(&p);
+            }
+
+            let response = request.send()?;
+
+            handle_response(response)
+        }
+    }
+
+    /// Processes a blocking response from the API and returns the result.
+    fn handle_response<T: DeserializeOwned>(response: Response) -> Result<T> {
+        match response.status() {
+            StatusCode::OK => Ok(response.json::<T>()?),
+            StatusCode::INTERNAL_SERVER_ERROR => {
+                let mut body = String::new();
+                response.take(1000).read_to_string(&mut body)?;
+                Err(Error::InternalServerError(truncate_body(body)))
+            }
+            StatusCode::UNAUTHORIZED => Err(Error::Unauthorized),
+            StatusCode::BAD_REQUEST => {
+                let mut body = String::new();
+                response.take(1000).read_to_string(&mut body)?;
+                Err(Error::BadRequest(truncate_body(body)))
+            }
+            status => Err(Error::UnexpectedStatusCode(status.as_u16())),
+        }
+    }
+
+    /// Builder for a blocking [`Client`], mirroring the async [`super::ClientBuilder`].
+    #[derive(Debug, Clone)]
+    pub struct ClientBuilder {
+        base_url: Option<String>,
+        api_key: Option<String>,
+        timeout: Duration,
+    }
+
+    impl ClientBuilder {
+        /// Creates a new builder with default settings.
+        pub fn new() -> Self {
+            ClientBuilder {
+                base_url: None,
+                api_key: None,
+                timeout: DEFAULT_TIMEOUT,
+            }
+        }
+
+        /// Sets the API key explicitly, overriding the `DATAMAXI_API_KEY` environment variable.
+        pub fn api_key(mut self, api_key: impl Into<String>) -> Self {
+            self.api_key = Some(api_key.into());
+            self
+        }
+
+        /// Overrides the base URL (defaults to the production API).
+        pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
+            self.base_url = Some(base_url.into());
+            self
+        }
+
+        /// Sets the per-request timeout (defaults to 10 seconds).
+        pub fn timeout(mut self, timeout: Duration) -> Self {
+            self.timeout = timeout;
+            self
+        }
+
+        /// Builds the blocking [`Client`], resolving the API key from the
+        /// explicit value or the `DATAMAXI_API_KEY` environment variable.
+        pub fn build(self) -> Result<Client> {
+            let api_key = self
+                .api_key
+                .or_else(|| std::env::var(API_KEY_ENV).ok())
+                .filter(|key| !key.trim().is_empty())
+                .ok_or(Error::MissingApiKey)?;
+
+            Ok(Client {
+                base_url: self.base_url.unwrap_or_else(|| BASE_URL.to_string()),
+                api_key,
+                inner_client: build_inner_client(self.timeout),
+            })
+        }
+    }
+
+    impl Default for ClientBuilder {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
 }

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -1242,7 +1242,7 @@ impl std::fmt::Display for CexAnnouncementsCategory {
 
 #[derive(Clone)]
 pub struct Announcements {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for Announcements {
@@ -1267,8 +1267,13 @@ impl Datamaxi for Announcements {
 }
 
 impl Announcements {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Get latest announcements from centralized exchanges
-    pub fn announcements(
+    pub async fn announcements(
         &self,
         options: CexAnnouncementsOptions,
     ) -> Result<CexAnnouncementsResponse> {
@@ -1293,6 +1298,7 @@ impl Announcements {
         }
         self.client
             .get("/api/v1/cex/announcements", Some(parameters))
+            .await
     }
 }
 
@@ -1453,7 +1459,7 @@ impl std::fmt::Display for CexCandleSymbolsMarket {
 
 #[derive(Clone)]
 pub struct CexCandle {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for CexCandle {
@@ -1478,8 +1484,13 @@ impl Datamaxi for CexCandle {
 }
 
 impl CexCandle {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Get historical candle data for a given `exchange`, `symbol`, `interval` and `market`.
-    pub fn get(
+    pub async fn get(
         &self,
         exchange: impl Into<String>,
         symbol: impl Into<String>,
@@ -1503,24 +1514,27 @@ impl CexCandle {
         if let Some(v) = options.to {
             parameters.insert("to".to_string(), v.to_string());
         }
-        self.client.get("/api/v1/cex/candle", Some(parameters))
+        self.client
+            .get("/api/v1/cex/candle", Some(parameters))
+            .await
     }
 
     /// Get supported exchanges accepted by `/api/v1/cex/candle` endpoint.
-    pub fn exchanges(&self, market: CexCandleExchangesMarket) -> Result<Vec<String>> {
+    pub async fn exchanges(&self, market: CexCandleExchangesMarket) -> Result<Vec<String>> {
         let mut parameters = HashMap::new();
         parameters.insert("market".to_string(), market.to_string());
         self.client
             .get("/api/v1/cex/candle/exchanges", Some(parameters))
+            .await
     }
 
     /// Fetch supported intervals accepted by `/api/v1/cex/candle` endpoint.
-    pub fn intervals(&self) -> Result<Vec<String>> {
-        self.client.get("/api/v1/cex/candle/intervals", None)
+    pub async fn intervals(&self) -> Result<Vec<String>> {
+        self.client.get("/api/v1/cex/candle/intervals", None).await
     }
 
     /// Fetch supported symbols accepted by `/api/v1/cex/candle` endpoint.
-    pub fn symbols(
+    pub async fn symbols(
         &self,
         exchange: impl Into<String>,
         options: CexCandleSymbolsOptions,
@@ -1532,6 +1546,7 @@ impl CexCandle {
         }
         self.client
             .get("/api/v1/cex/candle/symbols", Some(parameters))
+            .await
     }
 }
 
@@ -1807,7 +1822,7 @@ impl std::fmt::Display for CexSymbolVolumeMarket {
 
 #[derive(Clone)]
 pub struct CexSymbol {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for CexSymbol {
@@ -1832,8 +1847,13 @@ impl Datamaxi for CexSymbol {
 }
 
 impl CexSymbol {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Return currently-active caution/warning/danger flagged symbols. Bithumb provides an expiry (end_at); other exchanges are open-ended until the next collector poll clears them.
-    pub fn cautions(
+    pub async fn cautions(
         &self,
         options: CexSymbolCautionsOptions,
     ) -> Result<Vec<CexSymbolCautionsView>> {
@@ -1858,10 +1878,11 @@ impl CexSymbol {
         }
         self.client
             .get("/api/v1/cex/symbol/cautions", Some(parameters))
+            .await
     }
 
     /// Return symbols with a known delisting_at timestamp or trading_status in {delisting, delisted}. Filter by time window to get upcoming delistings.
-    pub fn delistings(
+    pub async fn delistings(
         &self,
         options: CexSymbolDelistingsOptions,
     ) -> Result<Vec<CexSymbolDelistingsView>> {
@@ -1889,10 +1910,11 @@ impl CexSymbol {
         }
         self.client
             .get("/api/v1/cex/symbol/delistings", Some(parameters))
+            .await
     }
 
     /// Sums long/short liquidation volume across all events in a rolling window for every exchange × quote pairing of the base asset. Window max 30d; default 24h.
-    pub fn liquidation(
+    pub async fn liquidation(
         &self,
         base: impl Into<String>,
         options: CexSymbolLiquidationOptions,
@@ -1904,10 +1926,11 @@ impl CexSymbol {
         }
         self.client
             .get("/api/v1/cex/symbol/liquidation", Some(parameters))
+            .await
     }
 
     /// Fetch per-symbol trading status, caution flags, tags and timing metadata collected by tfsymbolmeta.
-    pub fn metadata(
+    pub async fn metadata(
         &self,
         options: CexSymbolMetadataOptions,
     ) -> Result<Vec<CexSymbolMetadataView>> {
@@ -1935,10 +1958,11 @@ impl CexSymbol {
         }
         self.client
             .get("/api/v1/cex/symbol/metadata", Some(parameters))
+            .await
     }
 
     /// Latest Open Interest snapshot across every futures venue carrying the given base. Sorted by USD value descending, NULLs last.
-    pub fn oi(
+    pub async fn oi(
         &self,
         base: impl Into<String>,
         options: CexSymbolOiOptions,
@@ -1948,11 +1972,13 @@ impl CexSymbol {
         if let Some(v) = options.exchange {
             parameters.insert("exchange".to_string(), v.to_string());
         }
-        self.client.get("/api/v1/cex/symbol/oi", Some(parameters))
+        self.client
+            .get("/api/v1/cex/symbol/oi", Some(parameters))
+            .await
     }
 
     /// Enriched snapshot combining the latest OI (USD) with 1h/4h/24h change percentages and OI/24h volume ratio. Backed by the tfopeninterest taskflow's Redis HASH.
-    pub fn oi_stats(
+    pub async fn oi_stats(
         &self,
         base: impl Into<String>,
         options: CexSymbolOiStatsOptions,
@@ -1967,10 +1993,11 @@ impl CexSymbol {
         }
         self.client
             .get("/api/v1/cex/symbol/oi-stats", Some(parameters))
+            .await
     }
 
     /// Fetch (exchange, market, base, quote, tag) rows from cex_symbol_tag. Use to find every symbol flagged with a given tag (e.g. all meme coins across exchanges).
-    pub fn tags(&self, options: CexSymbolTagsOptions) -> Result<Vec<CexSymbolTagsView>> {
+    pub async fn tags(&self, options: CexSymbolTagsOptions) -> Result<Vec<CexSymbolTagsView>> {
         let mut parameters = HashMap::new();
         if let Some(v) = options.tag {
             parameters.insert("tag".to_string(), v.to_string());
@@ -1996,11 +2023,13 @@ impl CexSymbol {
         if let Some(v) = options.page {
             parameters.insert("page".to_string(), v.to_string());
         }
-        self.client.get("/api/v1/cex/symbol/tags", Some(parameters))
+        self.client
+            .get("/api/v1/cex/symbol/tags", Some(parameters))
+            .await
     }
 
     /// Latest 24h trading volume across every (exchange, market, quote) a token lists on. Backed by cache.latest_volume.
-    pub fn volume(
+    pub async fn volume(
         &self,
         base: impl Into<String>,
         options: CexSymbolVolumeOptions,
@@ -2012,6 +2041,7 @@ impl CexSymbol {
         }
         self.client
             .get("/api/v1/cex/symbol/volume", Some(parameters))
+            .await
     }
 }
 
@@ -2332,7 +2362,7 @@ impl CexSymbolVolumeOptions {
 
 #[derive(Clone)]
 pub struct Forex {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for Forex {
@@ -2357,16 +2387,21 @@ impl Datamaxi for Forex {
 }
 
 impl Forex {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Get the latest forex rate for given symbol.
-    pub fn get(&self, symbol: impl Into<String>) -> Result<ForexResponse> {
+    pub async fn get(&self, symbol: impl Into<String>) -> Result<ForexResponse> {
         let mut parameters = HashMap::new();
         parameters.insert("symbol".to_string(), symbol.into());
-        self.client.get("/api/v1/forex", Some(parameters))
+        self.client.get("/api/v1/forex", Some(parameters)).await
     }
 
     /// Get supported forex symbols.
-    pub fn symbols(&self) -> Result<Vec<String>> {
-        self.client.get("/api/v1/forex/symbols", None)
+    pub async fn symbols(&self) -> Result<Vec<String>> {
+        self.client.get("/api/v1/forex/symbols", None).await
     }
 }
 
@@ -2399,7 +2434,7 @@ impl std::fmt::Display for FundingRateHistorySort {
 
 #[derive(Clone)]
 pub struct FundingRate {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for FundingRate {
@@ -2424,13 +2459,20 @@ impl Datamaxi for FundingRate {
 }
 
 impl FundingRate {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Get supported exchanges accepted by `/api/v1/funding-rate` endpoint.
-    pub fn exchanges(&self) -> Result<Vec<String>> {
-        self.client.get("/api/v1/funding-rate/exchanges", None)
+    pub async fn exchanges(&self) -> Result<Vec<String>> {
+        self.client
+            .get("/api/v1/funding-rate/exchanges", None)
+            .await
     }
 
     /// Get historical funding rate data for a given `exchange` and `symbol`.
-    pub fn history(
+    pub async fn history(
         &self,
         exchange: impl Into<String>,
         symbol: impl Into<String>,
@@ -2456,10 +2498,11 @@ impl FundingRate {
         }
         self.client
             .get("/api/v1/funding-rate/history", Some(parameters))
+            .await
     }
 
     /// Fetch the latest funding rate data for a given `exchange` and `symbol`.
-    pub fn latest(
+    pub async fn latest(
         &self,
         exchange: impl Into<String>,
         symbol: impl Into<String>,
@@ -2469,10 +2512,11 @@ impl FundingRate {
         parameters.insert("symbol".to_string(), symbol.into());
         self.client
             .get("/api/v1/funding-rate/latest", Some(parameters))
+            .await
     }
 
     /// Fetch supported symbols accepted by `/api/v1/funding-rate` endpoint.
-    pub fn symbols(
+    pub async fn symbols(
         &self,
         options: FundingRateSymbolsOptions,
     ) -> Result<Vec<FundingRateSymbolsView>> {
@@ -2482,6 +2526,7 @@ impl FundingRate {
         }
         self.client
             .get("/api/v1/funding-rate/symbols", Some(parameters))
+            .await
     }
 }
 
@@ -2551,7 +2596,7 @@ impl FundingRateSymbolsOptions {
 
 #[derive(Clone)]
 pub struct IndexPrice {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for IndexPrice {
@@ -2576,8 +2621,13 @@ impl Datamaxi for IndexPrice {
 }
 
 impl IndexPrice {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Get index price
-    pub fn get(
+    pub async fn get(
         &self,
         asset: impl Into<String>,
         options: IndexPriceOptions,
@@ -2593,7 +2643,9 @@ impl IndexPrice {
         if let Some(v) = options.interval {
             parameters.insert("interval".to_string(), v.to_string());
         }
-        self.client.get("/api/v1/index-price", Some(parameters))
+        self.client
+            .get("/api/v1/index-price", Some(parameters))
+            .await
     }
 }
 
@@ -2741,7 +2793,7 @@ impl std::fmt::Display for LiquidationSymbolHistoryWindow {
 
 #[derive(Clone)]
 pub struct Liquidation {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for Liquidation {
@@ -2766,8 +2818,13 @@ impl Datamaxi for Liquidation {
 }
 
 impl Liquidation {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Fetch recent liquidation events for a futures symbol on a given exchange, newest first.
-    pub fn get(
+    pub async fn get(
         &self,
         exchange: impl Into<String>,
         symbol: impl Into<String>,
@@ -2779,11 +2836,13 @@ impl Liquidation {
         if let Some(v) = options.limit {
             parameters.insert("limit".to_string(), v.to_string());
         }
-        self.client.get("/api/v1/liquidation", Some(parameters))
+        self.client
+            .get("/api/v1/liquidation", Some(parameters))
+            .await
     }
 
     /// Fetch most recent liquidation events across all futures symbols, newest first. Use together with the `/ws/v1/liquidation/feed` firehose for a live feed view.
-    pub fn feed(&self, options: LiquidationFeedOptions) -> Result<LiquidationFeedResponse> {
+    pub async fn feed(&self, options: LiquidationFeedOptions) -> Result<LiquidationFeedResponse> {
         let mut parameters = HashMap::new();
         if let Some(v) = options.exchange {
             parameters.insert("exchange".to_string(), v.to_string());
@@ -2799,10 +2858,11 @@ impl Liquidation {
         }
         self.client
             .get("/api/v1/liquidation/feed", Some(parameters))
+            .await
     }
 
     /// Aggregated long/short liquidation USD by (token, exchange) over a rolling window. Result is cached for ~10s. Sub-1h windows are not supported; use the WS feed for finer granularity.
-    pub fn heatmap(
+    pub async fn heatmap(
         &self,
         options: LiquidationHeatmapOptions,
     ) -> Result<LiquidationHeatmapResponse> {
@@ -2815,10 +2875,11 @@ impl Liquidation {
         }
         self.client
             .get("/api/v1/liquidation/heatmap", Some(parameters))
+            .await
     }
 
     /// Coinglass-style liquidation map for one perpetual pair. Returns a price-grid breakdown of where leveraged positions would be liquidated, split by leverage tier (10x / 25x / 50x / 100x) and side (long below current price, short above). Built from current OI + last-24h candle entries + a fixed leverage-cohort prior. Read the `assumptions` field in the response for the modelling disclaimer. Cached server-side (~5s) so back-to-back polls are cheap.
-    pub fn map(&self, options: LiquidationMapOptions) -> Result<LiquidationMapResponse> {
+    pub async fn map(&self, options: LiquidationMapOptions) -> Result<LiquidationMapResponse> {
         let mut parameters = HashMap::new();
         if let Some(v) = options.exchange {
             parameters.insert("exchange".to_string(), v.to_string());
@@ -2829,11 +2890,16 @@ impl Liquidation {
         if let Some(v) = options.quote {
             parameters.insert("quote".to_string(), v.to_string());
         }
-        self.client.get("/api/v1/liquidation/map", Some(parameters))
+        self.client
+            .get("/api/v1/liquidation/map", Some(parameters))
+            .await
     }
 
     /// Aggregate liquidation stats (total, long/short split, count, venue count, biggest single event) over a 1h/4h/24h window. Backs the liquidation page KPI strip for windows the live feed buffer can't cover.
-    pub fn stats(&self, options: LiquidationStatsOptions) -> Result<LiquidationStatsResponse> {
+    pub async fn stats(
+        &self,
+        options: LiquidationStatsOptions,
+    ) -> Result<LiquidationStatsResponse> {
         let mut parameters = HashMap::new();
         if let Some(v) = options.window {
             parameters.insert("window".to_string(), v.to_string());
@@ -2846,10 +2912,11 @@ impl Liquidation {
         }
         self.client
             .get("/api/v1/liquidation/stats", Some(parameters))
+            .await
     }
 
     /// Bucketed long / short liquidation USD over time for a single (base, quote) pair, joined with the futures-candle close as a reference price line. Long/short USD comes from `cex.liquidation` (Side='sell' = long position liquidated, 'buy' = short). Price comes from `candle.futures_1m` on the requested exchange — or Binance as the reference when none is specified. Cached ~30s server-side.
-    pub fn symbol_history(
+    pub async fn symbol_history(
         &self,
         symbol: impl Into<String>,
         options: LiquidationSymbolHistoryOptions,
@@ -2870,6 +2937,7 @@ impl Liquidation {
         }
         self.client
             .get("/api/v1/liquidation/symbol-history", Some(parameters))
+            .await
     }
 }
 
@@ -3060,7 +3128,7 @@ impl LiquidationSymbolHistoryOptions {
 
 #[derive(Clone)]
 pub struct Listing {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for Listing {
@@ -3085,8 +3153,13 @@ impl Datamaxi for Listing {
 }
 
 impl Listing {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Get historical token listings for Upbit and Bithumb for KRW market
-    pub fn historical(
+    pub async fn historical(
         &self,
         options: ListingsHistoricalOptions,
     ) -> Result<ListingsHistoricalResponse> {
@@ -3096,6 +3169,7 @@ impl Listing {
         }
         self.client
             .get("/api/v1/listings/historical", Some(parameters))
+            .await
     }
 }
 
@@ -3119,7 +3193,7 @@ impl ListingsHistoricalOptions {
 
 #[derive(Clone)]
 pub struct MarginBorrow {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for MarginBorrow {
@@ -3144,11 +3218,18 @@ impl Datamaxi for MarginBorrow {
 }
 
 impl MarginBorrow {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Get the margin borrow data.
-    pub fn get(&self, asset: impl Into<String>) -> Result<MarginBorrowResponse> {
+    pub async fn get(&self, asset: impl Into<String>) -> Result<MarginBorrowResponse> {
         let mut parameters = HashMap::new();
         parameters.insert("asset".to_string(), asset.into());
-        self.client.get("/api/v1/margin-borrow", Some(parameters))
+        self.client
+            .get("/api/v1/margin-borrow", Some(parameters))
+            .await
     }
 }
 
@@ -3156,7 +3237,7 @@ impl MarginBorrow {
 
 #[derive(Clone)]
 pub struct NaverTrend {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for NaverTrend {
@@ -3181,16 +3262,23 @@ impl Datamaxi for NaverTrend {
 }
 
 impl NaverTrend {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Get Naver trend data with a daily frequency for a project that is associated with a given [symbol](./symbols). The values in response are normalized into a range from 0 to 100, where 0 corresponds to a minimum interest, and 100 corresponds to a maximum interest of users in Naver search engine.
-    pub fn get(&self, symbol: impl Into<String>) -> Result<Vec<NaverTrendView>> {
+    pub async fn get(&self, symbol: impl Into<String>) -> Result<Vec<NaverTrendView>> {
         let mut parameters = HashMap::new();
         parameters.insert("symbol".to_string(), symbol.into());
-        self.client.get("/api/v1/naver-trend", Some(parameters))
+        self.client
+            .get("/api/v1/naver-trend", Some(parameters))
+            .await
     }
 
     /// Get crypto symbols that are accepted by [Naver trend endpoint](./trend).
-    pub fn symbols(&self) -> Result<Vec<String>> {
-        self.client.get("/api/v1/naver-trend/symbols", None)
+    pub async fn symbols(&self) -> Result<Vec<String>> {
+        self.client.get("/api/v1/naver-trend/symbols", None).await
     }
 }
 
@@ -3254,7 +3342,7 @@ impl std::fmt::Display for OpenInterestOverviewSort {
 
 #[derive(Clone)]
 pub struct OpenInterest {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for OpenInterest {
@@ -3279,8 +3367,13 @@ impl Datamaxi for OpenInterest {
 }
 
 impl OpenInterest {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Fetch the most recent Open Interest snapshot for a futures symbol on a given exchange.
-    pub fn get(
+    pub async fn get(
         &self,
         exchange: impl Into<String>,
         symbol: impl Into<String>,
@@ -3288,11 +3381,13 @@ impl OpenInterest {
         let mut parameters = HashMap::new();
         parameters.insert("exchange".to_string(), exchange.into());
         parameters.insert("symbol".to_string(), symbol.into());
-        self.client.get("/api/v1/open-interest", Some(parameters))
+        self.client
+            .get("/api/v1/open-interest", Some(parameters))
+            .await
     }
 
     /// Historical Open Interest time series for a single token, broken down per exchange and aggregated to a fixed bucket (avg within bucket). The default lookback depends on the requested interval — 7 days for 1h, 30 days for 4h, 1 year for 1d — so callers don't have to hand-tune `from`/`to` for typical queries. The response also includes token metadata (icon, symbol, name) so a single call paints the whole header strip.
-    pub fn history_aggregated(
+    pub async fn history_aggregated(
         &self,
         token_id: impl Into<String>,
         options: OpenInterestHistoryAggregatedOptions,
@@ -3310,20 +3405,22 @@ impl OpenInterest {
         }
         self.client
             .get("/api/v1/open-interest/history-aggregated", Some(parameters))
+            .await
     }
 
     /// Fetch latest Open Interest snapshots across exchanges/symbols. Optionally filter by `exchange`. Results are sorted by `openInterestUsd` descending (null values last).
-    pub fn list(&self, options: OpenInterestListOptions) -> Result<OpenInterestListResponse> {
+    pub async fn list(&self, options: OpenInterestListOptions) -> Result<OpenInterestListResponse> {
         let mut parameters = HashMap::new();
         if let Some(v) = options.exchange {
             parameters.insert("exchange".to_string(), v.to_string());
         }
         self.client
             .get("/api/v1/open-interest/list", Some(parameters))
+            .await
     }
 
     /// Paginated token × exchange Open Interest matrix. For each base asset we list the per-exchange notional OI in USD (when a venue carries the token) and `null` when it doesn't trade there. The matrix is sortable by any exchange column and searchable by base symbol — same shape the DataMaxi+ dashboard uses on `/open-interest`. Cached snapshot rebuilds every few seconds, so back-to-back requests are cheap.
-    pub fn overview(
+    pub async fn overview(
         &self,
         options: OpenInterestOverviewOptions,
     ) -> Result<OpenInterestOverviewResponse> {
@@ -3345,10 +3442,11 @@ impl OpenInterest {
         }
         self.client
             .get("/api/v1/open-interest/overview", Some(parameters))
+            .await
     }
 
     /// Top-line aggregates over the current Open Interest snapshot — total OI USD, top tokens by OI, top exchanges by OI, and the count of venues currently reporting any base. Powers the OI page's KPI strip and breakdown card without forcing the caller to fetch the full token list.
-    pub fn summary(
+    pub async fn summary(
         &self,
         options: OpenInterestSummaryOptions,
     ) -> Result<OpenInterestSummaryResponse> {
@@ -3358,6 +3456,7 @@ impl OpenInterest {
         }
         self.client
             .get("/api/v1/open-interest/summary", Some(parameters))
+            .await
     }
 }
 
@@ -3577,7 +3676,7 @@ impl std::fmt::Display for PremiumSort {
 
 #[derive(Clone)]
 pub struct Premium {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for Premium {
@@ -3602,8 +3701,13 @@ impl Datamaxi for Premium {
 }
 
 impl Premium {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Get real-time premium (price difference) data across exchanges.
-    pub fn get(&self, options: PremiumOptions) -> Result<PremiumResponse> {
+    pub async fn get(&self, options: PremiumOptions) -> Result<PremiumResponse> {
         let mut parameters = HashMap::new();
         if let Some(v) = options.source_exchange {
             parameters.insert("source_exchange".to_string(), v.to_string());
@@ -3668,12 +3772,12 @@ impl Premium {
         if let Some(v) = options.token_exclude {
             parameters.insert("token_exclude".to_string(), v.to_string());
         }
-        self.client.get("/api/v1/premium", Some(parameters))
+        self.client.get("/api/v1/premium", Some(parameters)).await
     }
 
     /// Get supported source exchanges for premium data.
-    pub fn exchanges(&self) -> Result<Vec<String>> {
-        self.client.get("/api/v1/premium/exchanges", None)
+    pub async fn exchanges(&self) -> Result<Vec<String>> {
+        self.client.get("/api/v1/premium/exchanges", None).await
     }
 }
 
@@ -3974,7 +4078,7 @@ impl std::fmt::Display for TelegramMessagesCategory {
 
 #[derive(Clone)]
 pub struct Telegram {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for Telegram {
@@ -3999,8 +4103,16 @@ impl Datamaxi for Telegram {
 }
 
 impl Telegram {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Get Telegram channels
-    pub fn channels(&self, options: TelegramChannelsOptions) -> Result<TelegramChannelsResponse> {
+    pub async fn channels(
+        &self,
+        options: TelegramChannelsOptions,
+    ) -> Result<TelegramChannelsResponse> {
         let mut parameters = HashMap::new();
         if let Some(v) = options.page {
             parameters.insert("page".to_string(), v.to_string());
@@ -4019,10 +4131,14 @@ impl Telegram {
         }
         self.client
             .get("/api/v1/telegram/channels", Some(parameters))
+            .await
     }
 
     /// Get Telegram messages.
-    pub fn messages(&self, options: TelegramMessagesOptions) -> Result<TelegramMessagesResponse> {
+    pub async fn messages(
+        &self,
+        options: TelegramMessagesOptions,
+    ) -> Result<TelegramMessagesResponse> {
         let mut parameters = HashMap::new();
         if let Some(v) = options.channel {
             parameters.insert("channel".to_string(), v.to_string());
@@ -4047,6 +4163,7 @@ impl Telegram {
         }
         self.client
             .get("/api/v1/telegram/messages", Some(parameters))
+            .await
     }
 }
 
@@ -4285,7 +4402,7 @@ impl std::fmt::Display for TickerSymbolsMarket {
 
 #[derive(Clone)]
 pub struct Ticker {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for Ticker {
@@ -4310,8 +4427,13 @@ impl Datamaxi for Ticker {
 }
 
 impl Ticker {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Fetch the latest ticker for symbol from given exchange.
-    pub fn get(
+    pub async fn get(
         &self,
         exchange: impl Into<String>,
         symbol: impl Into<String>,
@@ -4331,19 +4453,20 @@ impl Ticker {
         if let Some(v) = options.include_source {
             parameters.insert("include_source".to_string(), v.to_string());
         }
-        self.client.get("/api/v1/ticker", Some(parameters))
+        self.client.get("/api/v1/ticker", Some(parameters)).await
     }
 
     /// Get supported exchanges accepted by `/api/v1/ticker` endpoint.
-    pub fn exchanges(&self, market: TickerExchangesMarket) -> Result<Vec<String>> {
+    pub async fn exchanges(&self, market: TickerExchangesMarket) -> Result<Vec<String>> {
         let mut parameters = HashMap::new();
         parameters.insert("market".to_string(), market.to_string());
         self.client
             .get("/api/v1/ticker/exchanges", Some(parameters))
+            .await
     }
 
     /// Get supported symbols accepted by `/api/v1/ticker` endpoint.
-    pub fn symbols(
+    pub async fn symbols(
         &self,
         exchange: impl Into<String>,
         market: TickerSymbolsMarket,
@@ -4351,7 +4474,9 @@ impl Ticker {
         let mut parameters = HashMap::new();
         parameters.insert("exchange".to_string(), exchange.into());
         parameters.insert("market".to_string(), market.to_string());
-        self.client.get("/api/v1/ticker/symbols", Some(parameters))
+        self.client
+            .get("/api/v1/ticker/symbols", Some(parameters))
+            .await
     }
 }
 
@@ -4416,7 +4541,7 @@ impl std::fmt::Display for CexTokenUpdatesType {
 
 #[derive(Clone)]
 pub struct Token {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for Token {
@@ -4441,8 +4566,16 @@ impl Datamaxi for Token {
 }
 
 impl Token {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Fetch latest token updates
-    pub fn updates(&self, options: CexTokenUpdatesOptions) -> Result<CexTokenUpdatesResponse> {
+    pub async fn updates(
+        &self,
+        options: CexTokenUpdatesOptions,
+    ) -> Result<CexTokenUpdatesResponse> {
         let mut parameters = HashMap::new();
         if let Some(v) = options.page {
             parameters.insert("page".to_string(), v.to_string());
@@ -4455,6 +4588,7 @@ impl Token {
         }
         self.client
             .get("/api/v1/cex/token/updates", Some(parameters))
+            .await
     }
 }
 
@@ -4494,7 +4628,7 @@ impl CexTokenUpdatesOptions {
 
 #[derive(Clone)]
 pub struct TradingFees {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for TradingFees {
@@ -4519,8 +4653,13 @@ impl Datamaxi for TradingFees {
 }
 
 impl TradingFees {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Get trading fees.
-    pub fn fees(&self, options: CexFeesOptions) -> Result<Vec<CexFeesView>> {
+    pub async fn fees(&self, options: CexFeesOptions) -> Result<Vec<CexFeesView>> {
         let mut parameters = HashMap::new();
         if let Some(v) = options.exchange {
             parameters.insert("exchange".to_string(), v.to_string());
@@ -4528,20 +4667,21 @@ impl TradingFees {
         if let Some(v) = options.symbol {
             parameters.insert("symbol".to_string(), v.to_string());
         }
-        self.client.get("/api/v1/cex/fees", Some(parameters))
+        self.client.get("/api/v1/cex/fees", Some(parameters)).await
     }
 
     /// Get supported exchanges accepted by `/api/v1/trading-fees` endpoint.
-    pub fn exchanges(&self) -> Result<Vec<String>> {
-        self.client.get("/api/v1/cex/fees/exchanges", None)
+    pub async fn exchanges(&self) -> Result<Vec<String>> {
+        self.client.get("/api/v1/cex/fees/exchanges", None).await
     }
 
     /// Get supported symbols accepted by `/api/v1/trading-fees` endpoint.
-    pub fn symbols(&self, exchange: impl Into<String>) -> Result<Vec<String>> {
+    pub async fn symbols(&self, exchange: impl Into<String>) -> Result<Vec<String>> {
         let mut parameters = HashMap::new();
         parameters.insert("exchange".to_string(), exchange.into());
         self.client
             .get("/api/v1/cex/fees/symbols", Some(parameters))
+            .await
     }
 }
 
@@ -4574,7 +4714,7 @@ impl CexFeesOptions {
 
 #[derive(Clone)]
 pub struct WalletStatus {
-    pub client: Client,
+    client: Client,
 }
 
 impl Datamaxi for WalletStatus {
@@ -4599,8 +4739,13 @@ impl Datamaxi for WalletStatus {
 }
 
 impl WalletStatus {
+    /// Wraps an already-built client (e.g. from `ClientBuilder`).
+    pub fn from_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Get the latest wallet status for asset from given exchange.
-    pub fn get(
+    pub async fn get(
         &self,
         asset: impl Into<String>,
         options: WalletStatusOptions,
@@ -4610,20 +4755,25 @@ impl WalletStatus {
         if let Some(v) = options.exchange {
             parameters.insert("exchange".to_string(), v.to_string());
         }
-        self.client.get("/api/v1/wallet-status", Some(parameters))
+        self.client
+            .get("/api/v1/wallet-status", Some(parameters))
+            .await
     }
 
     /// Get assets accepted by `/api/v1/wallet-status` endpoint.
-    pub fn assets(&self, exchange: impl Into<String>) -> Result<Vec<String>> {
+    pub async fn assets(&self, exchange: impl Into<String>) -> Result<Vec<String>> {
         let mut parameters = HashMap::new();
         parameters.insert("exchange".to_string(), exchange.into());
         self.client
             .get("/api/v1/wallet-status/assets", Some(parameters))
+            .await
     }
 
     /// Get exchanges accepted by `/api/v1/wallet-status` endpoint.
-    pub fn exchanges(&self) -> Result<Vec<String>> {
-        self.client.get("/api/v1/wallet-status/exchanges", None)
+    pub async fn exchanges(&self) -> Result<Vec<String>> {
+        self.client
+            .get("/api/v1/wallet-status/exchanges", None)
+            .await
     }
 }
 
@@ -4640,5 +4790,1432 @@ impl WalletStatusOptions {
     pub fn exchange(mut self, exchange: impl Into<String>) -> Self {
         self.exchange = Some(exchange.into());
         self
+    }
+}
+
+#[cfg(feature = "blocking")]
+pub mod blocking {
+    //! Synchronous mirror of the endpoint wrappers (feature `blocking`).
+    //!
+    //! Identical API to the async surface minus `async`/`.await`, backed by
+    //! [`crate::api::blocking::Client`]. Enums, Options, and response structs
+    //! are shared with the async surface via the glob import below.
+    use super::*;
+    use crate::api::blocking::Client;
+    use crate::api::{Config, Datamaxi, Result};
+    use std::collections::HashMap;
+
+    // --- Announcements ---
+
+    #[derive(Clone)]
+    pub struct Announcements {
+        client: Client,
+    }
+
+    impl Datamaxi for Announcements {
+        fn new(api_key: String) -> Announcements {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            Announcements {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> Announcements {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            Announcements {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl Announcements {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Get latest announcements from centralized exchanges
+        pub fn announcements(
+            &self,
+            options: CexAnnouncementsOptions,
+        ) -> Result<CexAnnouncementsResponse> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.page {
+                parameters.insert("page".to_string(), v.to_string());
+            }
+            if let Some(v) = options.limit {
+                parameters.insert("limit".to_string(), v.to_string());
+            }
+            if let Some(v) = options.sort {
+                parameters.insert("sort".to_string(), v.to_string());
+            }
+            if let Some(v) = options.key {
+                parameters.insert("key".to_string(), v.to_string());
+            }
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            if let Some(v) = options.category {
+                parameters.insert("category".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/cex/announcements", Some(parameters))
+        }
+    }
+
+    // --- CexCandle ---
+
+    #[derive(Clone)]
+    pub struct CexCandle {
+        client: Client,
+    }
+
+    impl Datamaxi for CexCandle {
+        fn new(api_key: String) -> CexCandle {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            CexCandle {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> CexCandle {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            CexCandle {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl CexCandle {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Get historical candle data for a given `exchange`, `symbol`, `interval` and `market`.
+        pub fn get(
+            &self,
+            exchange: impl Into<String>,
+            symbol: impl Into<String>,
+            options: CexCandleOptions,
+        ) -> Result<CexCandleResponse> {
+            let mut parameters = HashMap::new();
+            parameters.insert("exchange".to_string(), exchange.into());
+            parameters.insert("symbol".to_string(), symbol.into());
+            if let Some(v) = options.market {
+                parameters.insert("market".to_string(), v.to_string());
+            }
+            if let Some(v) = options.currency {
+                parameters.insert("currency".to_string(), v.to_string());
+            }
+            if let Some(v) = options.interval {
+                parameters.insert("interval".to_string(), v.to_string());
+            }
+            if let Some(v) = options.from {
+                parameters.insert("from".to_string(), v.to_string());
+            }
+            if let Some(v) = options.to {
+                parameters.insert("to".to_string(), v.to_string());
+            }
+            self.client.get("/api/v1/cex/candle", Some(parameters))
+        }
+
+        /// Get supported exchanges accepted by `/api/v1/cex/candle` endpoint.
+        pub fn exchanges(&self, market: CexCandleExchangesMarket) -> Result<Vec<String>> {
+            let mut parameters = HashMap::new();
+            parameters.insert("market".to_string(), market.to_string());
+            self.client
+                .get("/api/v1/cex/candle/exchanges", Some(parameters))
+        }
+
+        /// Fetch supported intervals accepted by `/api/v1/cex/candle` endpoint.
+        pub fn intervals(&self) -> Result<Vec<String>> {
+            self.client.get("/api/v1/cex/candle/intervals", None)
+        }
+
+        /// Fetch supported symbols accepted by `/api/v1/cex/candle` endpoint.
+        pub fn symbols(
+            &self,
+            exchange: impl Into<String>,
+            options: CexCandleSymbolsOptions,
+        ) -> Result<Vec<CexCandleSymbolsView>> {
+            let mut parameters = HashMap::new();
+            parameters.insert("exchange".to_string(), exchange.into());
+            if let Some(v) = options.market {
+                parameters.insert("market".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/cex/candle/symbols", Some(parameters))
+        }
+    }
+
+    // --- CexSymbol ---
+
+    #[derive(Clone)]
+    pub struct CexSymbol {
+        client: Client,
+    }
+
+    impl Datamaxi for CexSymbol {
+        fn new(api_key: String) -> CexSymbol {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            CexSymbol {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> CexSymbol {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            CexSymbol {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl CexSymbol {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Return currently-active caution/warning/danger flagged symbols. Bithumb provides an expiry (end_at); other exchanges are open-ended until the next collector poll clears them.
+        pub fn cautions(
+            &self,
+            options: CexSymbolCautionsOptions,
+        ) -> Result<Vec<CexSymbolCautionsView>> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            if let Some(v) = options.market {
+                parameters.insert("market".to_string(), v.to_string());
+            }
+            if let Some(v) = options.min_level {
+                parameters.insert("min_level".to_string(), v.to_string());
+            }
+            if let Some(v) = options.active_only {
+                parameters.insert("active_only".to_string(), v.to_string());
+            }
+            if let Some(v) = options.limit {
+                parameters.insert("limit".to_string(), v.to_string());
+            }
+            if let Some(v) = options.page {
+                parameters.insert("page".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/cex/symbol/cautions", Some(parameters))
+        }
+
+        /// Return symbols with a known delisting_at timestamp or trading_status in {delisting, delisted}. Filter by time window to get upcoming delistings.
+        pub fn delistings(
+            &self,
+            options: CexSymbolDelistingsOptions,
+        ) -> Result<Vec<CexSymbolDelistingsView>> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            if let Some(v) = options.market {
+                parameters.insert("market".to_string(), v.to_string());
+            }
+            if let Some(v) = options.from_ms {
+                parameters.insert("from_ms".to_string(), v.to_string());
+            }
+            if let Some(v) = options.to_ms {
+                parameters.insert("to_ms".to_string(), v.to_string());
+            }
+            if let Some(v) = options.include_past {
+                parameters.insert("include_past".to_string(), v.to_string());
+            }
+            if let Some(v) = options.limit {
+                parameters.insert("limit".to_string(), v.to_string());
+            }
+            if let Some(v) = options.page {
+                parameters.insert("page".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/cex/symbol/delistings", Some(parameters))
+        }
+
+        /// Sums long/short liquidation volume across all events in a rolling window for every exchange × quote pairing of the base asset. Window max 30d; default 24h.
+        pub fn liquidation(
+            &self,
+            base: impl Into<String>,
+            options: CexSymbolLiquidationOptions,
+        ) -> Result<Vec<CexSymbolLiquidationView>> {
+            let mut parameters = HashMap::new();
+            parameters.insert("base".to_string(), base.into());
+            if let Some(v) = options.window {
+                parameters.insert("window".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/cex/symbol/liquidation", Some(parameters))
+        }
+
+        /// Fetch per-symbol trading status, caution flags, tags and timing metadata collected by tfsymbolmeta.
+        pub fn metadata(
+            &self,
+            options: CexSymbolMetadataOptions,
+        ) -> Result<Vec<CexSymbolMetadataView>> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            if let Some(v) = options.market {
+                parameters.insert("market".to_string(), v.to_string());
+            }
+            if let Some(v) = options.base {
+                parameters.insert("base".to_string(), v.to_string());
+            }
+            if let Some(v) = options.quote {
+                parameters.insert("quote".to_string(), v.to_string());
+            }
+            if let Some(v) = options.status {
+                parameters.insert("status".to_string(), v.to_string());
+            }
+            if let Some(v) = options.limit {
+                parameters.insert("limit".to_string(), v.to_string());
+            }
+            if let Some(v) = options.page {
+                parameters.insert("page".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/cex/symbol/metadata", Some(parameters))
+        }
+
+        /// Latest Open Interest snapshot across every futures venue carrying the given base. Sorted by USD value descending, NULLs last.
+        pub fn oi(
+            &self,
+            base: impl Into<String>,
+            options: CexSymbolOiOptions,
+        ) -> Result<Vec<CexSymbolOiView>> {
+            let mut parameters = HashMap::new();
+            parameters.insert("base".to_string(), base.into());
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            self.client.get("/api/v1/cex/symbol/oi", Some(parameters))
+        }
+
+        /// Enriched snapshot combining the latest OI (USD) with 1h/4h/24h change percentages and OI/24h volume ratio. Backed by the tfopeninterest taskflow's Redis HASH.
+        pub fn oi_stats(
+            &self,
+            base: impl Into<String>,
+            options: CexSymbolOiStatsOptions,
+        ) -> Result<Vec<CexSymbolOiStatsView>> {
+            let mut parameters = HashMap::new();
+            parameters.insert("base".to_string(), base.into());
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            if let Some(v) = options.currency {
+                parameters.insert("currency".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/cex/symbol/oi-stats", Some(parameters))
+        }
+
+        /// Fetch (exchange, market, base, quote, tag) rows from cex_symbol_tag. Use to find every symbol flagged with a given tag (e.g. all meme coins across exchanges).
+        pub fn tags(&self, options: CexSymbolTagsOptions) -> Result<Vec<CexSymbolTagsView>> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.tag {
+                parameters.insert("tag".to_string(), v.to_string());
+            }
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            if let Some(v) = options.market {
+                parameters.insert("market".to_string(), v.to_string());
+            }
+            if let Some(v) = options.base {
+                parameters.insert("base".to_string(), v.to_string());
+            }
+            if let Some(v) = options.source {
+                parameters.insert("source".to_string(), v.to_string());
+            }
+            if let Some(v) = options.min_confidence {
+                parameters.insert("min_confidence".to_string(), v.to_string());
+            }
+            if let Some(v) = options.limit {
+                parameters.insert("limit".to_string(), v.to_string());
+            }
+            if let Some(v) = options.page {
+                parameters.insert("page".to_string(), v.to_string());
+            }
+            self.client.get("/api/v1/cex/symbol/tags", Some(parameters))
+        }
+
+        /// Latest 24h trading volume across every (exchange, market, quote) a token lists on. Backed by cache.latest_volume.
+        pub fn volume(
+            &self,
+            base: impl Into<String>,
+            options: CexSymbolVolumeOptions,
+        ) -> Result<Vec<CexSymbolVolumeView>> {
+            let mut parameters = HashMap::new();
+            parameters.insert("base".to_string(), base.into());
+            if let Some(v) = options.market {
+                parameters.insert("market".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/cex/symbol/volume", Some(parameters))
+        }
+    }
+
+    // --- Forex ---
+
+    #[derive(Clone)]
+    pub struct Forex {
+        client: Client,
+    }
+
+    impl Datamaxi for Forex {
+        fn new(api_key: String) -> Forex {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            Forex {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> Forex {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            Forex {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl Forex {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Get the latest forex rate for given symbol.
+        pub fn get(&self, symbol: impl Into<String>) -> Result<ForexResponse> {
+            let mut parameters = HashMap::new();
+            parameters.insert("symbol".to_string(), symbol.into());
+            self.client.get("/api/v1/forex", Some(parameters))
+        }
+
+        /// Get supported forex symbols.
+        pub fn symbols(&self) -> Result<Vec<String>> {
+            self.client.get("/api/v1/forex/symbols", None)
+        }
+    }
+
+    // --- FundingRate ---
+
+    #[derive(Clone)]
+    pub struct FundingRate {
+        client: Client,
+    }
+
+    impl Datamaxi for FundingRate {
+        fn new(api_key: String) -> FundingRate {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            FundingRate {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> FundingRate {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            FundingRate {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl FundingRate {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Get supported exchanges accepted by `/api/v1/funding-rate` endpoint.
+        pub fn exchanges(&self) -> Result<Vec<String>> {
+            self.client.get("/api/v1/funding-rate/exchanges", None)
+        }
+
+        /// Get historical funding rate data for a given `exchange` and `symbol`.
+        pub fn history(
+            &self,
+            exchange: impl Into<String>,
+            symbol: impl Into<String>,
+            options: FundingRateHistoryOptions,
+        ) -> Result<FundingRateHistoryResponse> {
+            let mut parameters = HashMap::new();
+            parameters.insert("exchange".to_string(), exchange.into());
+            parameters.insert("symbol".to_string(), symbol.into());
+            if let Some(v) = options.page {
+                parameters.insert("page".to_string(), v.to_string());
+            }
+            if let Some(v) = options.limit {
+                parameters.insert("limit".to_string(), v.to_string());
+            }
+            if let Some(v) = options.from {
+                parameters.insert("from".to_string(), v.to_string());
+            }
+            if let Some(v) = options.to {
+                parameters.insert("to".to_string(), v.to_string());
+            }
+            if let Some(v) = options.sort {
+                parameters.insert("sort".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/funding-rate/history", Some(parameters))
+        }
+
+        /// Fetch the latest funding rate data for a given `exchange` and `symbol`.
+        pub fn latest(
+            &self,
+            exchange: impl Into<String>,
+            symbol: impl Into<String>,
+        ) -> Result<FundingRateLatestResponse> {
+            let mut parameters = HashMap::new();
+            parameters.insert("exchange".to_string(), exchange.into());
+            parameters.insert("symbol".to_string(), symbol.into());
+            self.client
+                .get("/api/v1/funding-rate/latest", Some(parameters))
+        }
+
+        /// Fetch supported symbols accepted by `/api/v1/funding-rate` endpoint.
+        pub fn symbols(
+            &self,
+            options: FundingRateSymbolsOptions,
+        ) -> Result<Vec<FundingRateSymbolsView>> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/funding-rate/symbols", Some(parameters))
+        }
+    }
+
+    // --- IndexPrice ---
+
+    #[derive(Clone)]
+    pub struct IndexPrice {
+        client: Client,
+    }
+
+    impl Datamaxi for IndexPrice {
+        fn new(api_key: String) -> IndexPrice {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            IndexPrice {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> IndexPrice {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            IndexPrice {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl IndexPrice {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Get index price
+        pub fn get(
+            &self,
+            asset: impl Into<String>,
+            options: IndexPriceOptions,
+        ) -> Result<IndexPriceResponse> {
+            let mut parameters = HashMap::new();
+            parameters.insert("asset".to_string(), asset.into());
+            if let Some(v) = options.from {
+                parameters.insert("from".to_string(), v.to_string());
+            }
+            if let Some(v) = options.to {
+                parameters.insert("to".to_string(), v.to_string());
+            }
+            if let Some(v) = options.interval {
+                parameters.insert("interval".to_string(), v.to_string());
+            }
+            self.client.get("/api/v1/index-price", Some(parameters))
+        }
+    }
+
+    // --- Liquidation ---
+
+    #[derive(Clone)]
+    pub struct Liquidation {
+        client: Client,
+    }
+
+    impl Datamaxi for Liquidation {
+        fn new(api_key: String) -> Liquidation {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            Liquidation {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> Liquidation {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            Liquidation {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl Liquidation {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Fetch recent liquidation events for a futures symbol on a given exchange, newest first.
+        pub fn get(
+            &self,
+            exchange: impl Into<String>,
+            symbol: impl Into<String>,
+            options: LiquidationOptions,
+        ) -> Result<LiquidationResponse> {
+            let mut parameters = HashMap::new();
+            parameters.insert("exchange".to_string(), exchange.into());
+            parameters.insert("symbol".to_string(), symbol.into());
+            if let Some(v) = options.limit {
+                parameters.insert("limit".to_string(), v.to_string());
+            }
+            self.client.get("/api/v1/liquidation", Some(parameters))
+        }
+
+        /// Fetch most recent liquidation events across all futures symbols, newest first. Use together with the `/ws/v1/liquidation/feed` firehose for a live feed view.
+        pub fn feed(&self, options: LiquidationFeedOptions) -> Result<LiquidationFeedResponse> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            if let Some(v) = options.base {
+                parameters.insert("base".to_string(), v.to_string());
+            }
+            if let Some(v) = options.min_volume_usd {
+                parameters.insert("min_volume_usd".to_string(), v.to_string());
+            }
+            if let Some(v) = options.limit {
+                parameters.insert("limit".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/liquidation/feed", Some(parameters))
+        }
+
+        /// Aggregated long/short liquidation USD by (token, exchange) over a rolling window. Result is cached for ~10s. Sub-1h windows are not supported; use the WS feed for finer granularity.
+        pub fn heatmap(
+            &self,
+            options: LiquidationHeatmapOptions,
+        ) -> Result<LiquidationHeatmapResponse> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.window {
+                parameters.insert("window".to_string(), v.to_string());
+            }
+            if let Some(v) = options.top_n {
+                parameters.insert("top_n".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/liquidation/heatmap", Some(parameters))
+        }
+
+        /// Coinglass-style liquidation map for one perpetual pair. Returns a price-grid breakdown of where leveraged positions would be liquidated, split by leverage tier (10x / 25x / 50x / 100x) and side (long below current price, short above). Built from current OI + last-24h candle entries + a fixed leverage-cohort prior. Read the `assumptions` field in the response for the modelling disclaimer. Cached server-side (~5s) so back-to-back polls are cheap.
+        pub fn map(&self, options: LiquidationMapOptions) -> Result<LiquidationMapResponse> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            if let Some(v) = options.base {
+                parameters.insert("base".to_string(), v.to_string());
+            }
+            if let Some(v) = options.quote {
+                parameters.insert("quote".to_string(), v.to_string());
+            }
+            self.client.get("/api/v1/liquidation/map", Some(parameters))
+        }
+
+        /// Aggregate liquidation stats (total, long/short split, count, venue count, biggest single event) over a 1h/4h/24h window. Backs the liquidation page KPI strip for windows the live feed buffer can't cover.
+        pub fn stats(&self, options: LiquidationStatsOptions) -> Result<LiquidationStatsResponse> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.window {
+                parameters.insert("window".to_string(), v.to_string());
+            }
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            if let Some(v) = options.min_volume_usd {
+                parameters.insert("min_volume_usd".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/liquidation/stats", Some(parameters))
+        }
+
+        /// Bucketed long / short liquidation USD over time for a single (base, quote) pair, joined with the futures-candle close as a reference price line. Long/short USD comes from `cex.liquidation` (Side='sell' = long position liquidated, 'buy' = short). Price comes from `candle.futures_1m` on the requested exchange — or Binance as the reference when none is specified. Cached ~30s server-side.
+        pub fn symbol_history(
+            &self,
+            symbol: impl Into<String>,
+            options: LiquidationSymbolHistoryOptions,
+        ) -> Result<LiquidationSymbolHistoryResponse> {
+            let mut parameters = HashMap::new();
+            parameters.insert("symbol".to_string(), symbol.into());
+            if let Some(v) = options.quote {
+                parameters.insert("quote".to_string(), v.to_string());
+            }
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            if let Some(v) = options.interval {
+                parameters.insert("interval".to_string(), v.to_string());
+            }
+            if let Some(v) = options.window {
+                parameters.insert("window".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/liquidation/symbol-history", Some(parameters))
+        }
+    }
+
+    // --- Listing ---
+
+    #[derive(Clone)]
+    pub struct Listing {
+        client: Client,
+    }
+
+    impl Datamaxi for Listing {
+        fn new(api_key: String) -> Listing {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            Listing {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> Listing {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            Listing {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl Listing {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Get historical token listings for Upbit and Bithumb for KRW market
+        pub fn historical(
+            &self,
+            options: ListingsHistoricalOptions,
+        ) -> Result<ListingsHistoricalResponse> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.refresh {
+                parameters.insert("refresh".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/listings/historical", Some(parameters))
+        }
+    }
+
+    // --- MarginBorrow ---
+
+    #[derive(Clone)]
+    pub struct MarginBorrow {
+        client: Client,
+    }
+
+    impl Datamaxi for MarginBorrow {
+        fn new(api_key: String) -> MarginBorrow {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            MarginBorrow {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> MarginBorrow {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            MarginBorrow {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl MarginBorrow {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Get the margin borrow data.
+        pub fn get(&self, asset: impl Into<String>) -> Result<MarginBorrowResponse> {
+            let mut parameters = HashMap::new();
+            parameters.insert("asset".to_string(), asset.into());
+            self.client.get("/api/v1/margin-borrow", Some(parameters))
+        }
+    }
+
+    // --- NaverTrend ---
+
+    #[derive(Clone)]
+    pub struct NaverTrend {
+        client: Client,
+    }
+
+    impl Datamaxi for NaverTrend {
+        fn new(api_key: String) -> NaverTrend {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            NaverTrend {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> NaverTrend {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            NaverTrend {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl NaverTrend {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Get Naver trend data with a daily frequency for a project that is associated with a given [symbol](./symbols). The values in response are normalized into a range from 0 to 100, where 0 corresponds to a minimum interest, and 100 corresponds to a maximum interest of users in Naver search engine.
+        pub fn get(&self, symbol: impl Into<String>) -> Result<Vec<NaverTrendView>> {
+            let mut parameters = HashMap::new();
+            parameters.insert("symbol".to_string(), symbol.into());
+            self.client.get("/api/v1/naver-trend", Some(parameters))
+        }
+
+        /// Get crypto symbols that are accepted by [Naver trend endpoint](./trend).
+        pub fn symbols(&self) -> Result<Vec<String>> {
+            self.client.get("/api/v1/naver-trend/symbols", None)
+        }
+    }
+
+    // --- OpenInterest ---
+
+    #[derive(Clone)]
+    pub struct OpenInterest {
+        client: Client,
+    }
+
+    impl Datamaxi for OpenInterest {
+        fn new(api_key: String) -> OpenInterest {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            OpenInterest {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> OpenInterest {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            OpenInterest {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl OpenInterest {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Fetch the most recent Open Interest snapshot for a futures symbol on a given exchange.
+        pub fn get(
+            &self,
+            exchange: impl Into<String>,
+            symbol: impl Into<String>,
+        ) -> Result<OpenInterestResponse> {
+            let mut parameters = HashMap::new();
+            parameters.insert("exchange".to_string(), exchange.into());
+            parameters.insert("symbol".to_string(), symbol.into());
+            self.client.get("/api/v1/open-interest", Some(parameters))
+        }
+
+        /// Historical Open Interest time series for a single token, broken down per exchange and aggregated to a fixed bucket (avg within bucket). The default lookback depends on the requested interval — 7 days for 1h, 30 days for 4h, 1 year for 1d — so callers don't have to hand-tune `from`/`to` for typical queries. The response also includes token metadata (icon, symbol, name) so a single call paints the whole header strip.
+        pub fn history_aggregated(
+            &self,
+            token_id: impl Into<String>,
+            options: OpenInterestHistoryAggregatedOptions,
+        ) -> Result<OpenInterestHistoryAggregatedResponse> {
+            let mut parameters = HashMap::new();
+            parameters.insert("token_id".to_string(), token_id.into());
+            if let Some(v) = options.interval {
+                parameters.insert("interval".to_string(), v.to_string());
+            }
+            if let Some(v) = options.from {
+                parameters.insert("from".to_string(), v.to_string());
+            }
+            if let Some(v) = options.to {
+                parameters.insert("to".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/open-interest/history-aggregated", Some(parameters))
+        }
+
+        /// Fetch latest Open Interest snapshots across exchanges/symbols. Optionally filter by `exchange`. Results are sorted by `openInterestUsd` descending (null values last).
+        pub fn list(&self, options: OpenInterestListOptions) -> Result<OpenInterestListResponse> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/open-interest/list", Some(parameters))
+        }
+
+        /// Paginated token × exchange Open Interest matrix. For each base asset we list the per-exchange notional OI in USD (when a venue carries the token) and `null` when it doesn't trade there. The matrix is sortable by any exchange column and searchable by base symbol — same shape the DataMaxi+ dashboard uses on `/open-interest`. Cached snapshot rebuilds every few seconds, so back-to-back requests are cheap.
+        pub fn overview(
+            &self,
+            options: OpenInterestOverviewOptions,
+        ) -> Result<OpenInterestOverviewResponse> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.page {
+                parameters.insert("page".to_string(), v.to_string());
+            }
+            if let Some(v) = options.limit {
+                parameters.insert("limit".to_string(), v.to_string());
+            }
+            if let Some(v) = options.key {
+                parameters.insert("key".to_string(), v.to_string());
+            }
+            if let Some(v) = options.sort {
+                parameters.insert("sort".to_string(), v.to_string());
+            }
+            if let Some(v) = options.query {
+                parameters.insert("query".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/open-interest/overview", Some(parameters))
+        }
+
+        /// Top-line aggregates over the current Open Interest snapshot — total OI USD, top tokens by OI, top exchanges by OI, and the count of venues currently reporting any base. Powers the OI page's KPI strip and breakdown card without forcing the caller to fetch the full token list.
+        pub fn summary(
+            &self,
+            options: OpenInterestSummaryOptions,
+        ) -> Result<OpenInterestSummaryResponse> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.top_n {
+                parameters.insert("top_n".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/open-interest/summary", Some(parameters))
+        }
+    }
+
+    // --- Premium ---
+
+    #[derive(Clone)]
+    pub struct Premium {
+        client: Client,
+    }
+
+    impl Datamaxi for Premium {
+        fn new(api_key: String) -> Premium {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            Premium {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> Premium {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            Premium {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl Premium {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Get real-time premium (price difference) data across exchanges.
+        pub fn get(&self, options: PremiumOptions) -> Result<PremiumResponse> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.source_exchange {
+                parameters.insert("source_exchange".to_string(), v.to_string());
+            }
+            if let Some(v) = options.target_exchange {
+                parameters.insert("target_exchange".to_string(), v.to_string());
+            }
+            if let Some(v) = options.asset {
+                parameters.insert("asset".to_string(), v.to_string());
+            }
+            if let Some(v) = options.source_quote {
+                parameters.insert("source_quote".to_string(), v.to_string());
+            }
+            if let Some(v) = options.target_quote {
+                parameters.insert("target_quote".to_string(), v.to_string());
+            }
+            if let Some(v) = options.source_market {
+                parameters.insert("source_market".to_string(), v.to_string());
+            }
+            if let Some(v) = options.target_market {
+                parameters.insert("target_market".to_string(), v.to_string());
+            }
+            if let Some(v) = options.premium_type {
+                parameters.insert("premium_type".to_string(), v.to_string());
+            }
+            if let Some(v) = options.currency {
+                parameters.insert("currency".to_string(), v.to_string());
+            }
+            if let Some(v) = options.conversion_base {
+                parameters.insert("conversion_base".to_string(), v.to_string());
+            }
+            if let Some(v) = options.page {
+                parameters.insert("page".to_string(), v.to_string());
+            }
+            if let Some(v) = options.limit {
+                parameters.insert("limit".to_string(), v.to_string());
+            }
+            if let Some(v) = options.sort {
+                parameters.insert("sort".to_string(), v.to_string());
+            }
+            if let Some(v) = options.key {
+                parameters.insert("key".to_string(), v.to_string());
+            }
+            if let Some(v) = options.query {
+                parameters.insert("query".to_string(), v.to_string());
+            }
+            if let Some(v) = options.only_transferable {
+                parameters.insert("only_transferable".to_string(), v.to_string());
+            }
+            if let Some(v) = options.network {
+                parameters.insert("network".to_string(), v.to_string());
+            }
+            if let Some(v) = options.min_sv {
+                parameters.insert("min_sv".to_string(), v.to_string());
+            }
+            if let Some(v) = options.min_tv {
+                parameters.insert("min_tv".to_string(), v.to_string());
+            }
+            if let Some(v) = options.token_include {
+                parameters.insert("token_include".to_string(), v.to_string());
+            }
+            if let Some(v) = options.token_exclude {
+                parameters.insert("token_exclude".to_string(), v.to_string());
+            }
+            self.client.get("/api/v1/premium", Some(parameters))
+        }
+
+        /// Get supported source exchanges for premium data.
+        pub fn exchanges(&self) -> Result<Vec<String>> {
+            self.client.get("/api/v1/premium/exchanges", None)
+        }
+    }
+
+    // --- Telegram ---
+
+    #[derive(Clone)]
+    pub struct Telegram {
+        client: Client,
+    }
+
+    impl Datamaxi for Telegram {
+        fn new(api_key: String) -> Telegram {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            Telegram {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> Telegram {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            Telegram {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl Telegram {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Get Telegram channels
+        pub fn channels(
+            &self,
+            options: TelegramChannelsOptions,
+        ) -> Result<TelegramChannelsResponse> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.page {
+                parameters.insert("page".to_string(), v.to_string());
+            }
+            if let Some(v) = options.limit {
+                parameters.insert("limit".to_string(), v.to_string());
+            }
+            if let Some(v) = options.category {
+                parameters.insert("category".to_string(), v.to_string());
+            }
+            if let Some(v) = options.key {
+                parameters.insert("key".to_string(), v.to_string());
+            }
+            if let Some(v) = options.sort {
+                parameters.insert("sort".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/telegram/channels", Some(parameters))
+        }
+
+        /// Get Telegram messages.
+        pub fn messages(
+            &self,
+            options: TelegramMessagesOptions,
+        ) -> Result<TelegramMessagesResponse> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.channel {
+                parameters.insert("channel".to_string(), v.to_string());
+            }
+            if let Some(v) = options.page {
+                parameters.insert("page".to_string(), v.to_string());
+            }
+            if let Some(v) = options.limit {
+                parameters.insert("limit".to_string(), v.to_string());
+            }
+            if let Some(v) = options.key {
+                parameters.insert("key".to_string(), v.to_string());
+            }
+            if let Some(v) = options.sort {
+                parameters.insert("sort".to_string(), v.to_string());
+            }
+            if let Some(v) = options.category {
+                parameters.insert("category".to_string(), v.to_string());
+            }
+            if let Some(v) = options.search_query {
+                parameters.insert("search_query".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/telegram/messages", Some(parameters))
+        }
+    }
+
+    // --- Ticker ---
+
+    #[derive(Clone)]
+    pub struct Ticker {
+        client: Client,
+    }
+
+    impl Datamaxi for Ticker {
+        fn new(api_key: String) -> Ticker {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            Ticker {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> Ticker {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            Ticker {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl Ticker {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Fetch the latest ticker for symbol from given exchange.
+        pub fn get(
+            &self,
+            exchange: impl Into<String>,
+            symbol: impl Into<String>,
+            market: TickerMarket,
+            options: TickerOptions,
+        ) -> Result<TickerResponse> {
+            let mut parameters = HashMap::new();
+            parameters.insert("exchange".to_string(), exchange.into());
+            parameters.insert("symbol".to_string(), symbol.into());
+            parameters.insert("market".to_string(), market.to_string());
+            if let Some(v) = options.currency {
+                parameters.insert("currency".to_string(), v.to_string());
+            }
+            if let Some(v) = options.conversion_base {
+                parameters.insert("conversion_base".to_string(), v.to_string());
+            }
+            if let Some(v) = options.include_source {
+                parameters.insert("include_source".to_string(), v.to_string());
+            }
+            self.client.get("/api/v1/ticker", Some(parameters))
+        }
+
+        /// Get supported exchanges accepted by `/api/v1/ticker` endpoint.
+        pub fn exchanges(&self, market: TickerExchangesMarket) -> Result<Vec<String>> {
+            let mut parameters = HashMap::new();
+            parameters.insert("market".to_string(), market.to_string());
+            self.client
+                .get("/api/v1/ticker/exchanges", Some(parameters))
+        }
+
+        /// Get supported symbols accepted by `/api/v1/ticker` endpoint.
+        pub fn symbols(
+            &self,
+            exchange: impl Into<String>,
+            market: TickerSymbolsMarket,
+        ) -> Result<Vec<String>> {
+            let mut parameters = HashMap::new();
+            parameters.insert("exchange".to_string(), exchange.into());
+            parameters.insert("market".to_string(), market.to_string());
+            self.client.get("/api/v1/ticker/symbols", Some(parameters))
+        }
+    }
+
+    // --- Token ---
+
+    #[derive(Clone)]
+    pub struct Token {
+        client: Client,
+    }
+
+    impl Datamaxi for Token {
+        fn new(api_key: String) -> Token {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            Token {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> Token {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            Token {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl Token {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Fetch latest token updates
+        pub fn updates(&self, options: CexTokenUpdatesOptions) -> Result<CexTokenUpdatesResponse> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.page {
+                parameters.insert("page".to_string(), v.to_string());
+            }
+            if let Some(v) = options.limit {
+                parameters.insert("limit".to_string(), v.to_string());
+            }
+            if let Some(v) = options.r#type {
+                parameters.insert("type".to_string(), v.to_string());
+            }
+            self.client
+                .get("/api/v1/cex/token/updates", Some(parameters))
+        }
+    }
+
+    // --- TradingFees ---
+
+    #[derive(Clone)]
+    pub struct TradingFees {
+        client: Client,
+    }
+
+    impl Datamaxi for TradingFees {
+        fn new(api_key: String) -> TradingFees {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            TradingFees {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> TradingFees {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            TradingFees {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl TradingFees {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Get trading fees.
+        pub fn fees(&self, options: CexFeesOptions) -> Result<Vec<CexFeesView>> {
+            let mut parameters = HashMap::new();
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            if let Some(v) = options.symbol {
+                parameters.insert("symbol".to_string(), v.to_string());
+            }
+            self.client.get("/api/v1/cex/fees", Some(parameters))
+        }
+
+        /// Get supported exchanges accepted by `/api/v1/trading-fees` endpoint.
+        pub fn exchanges(&self) -> Result<Vec<String>> {
+            self.client.get("/api/v1/cex/fees/exchanges", None)
+        }
+
+        /// Get supported symbols accepted by `/api/v1/trading-fees` endpoint.
+        pub fn symbols(&self, exchange: impl Into<String>) -> Result<Vec<String>> {
+            let mut parameters = HashMap::new();
+            parameters.insert("exchange".to_string(), exchange.into());
+            self.client
+                .get("/api/v1/cex/fees/symbols", Some(parameters))
+        }
+    }
+
+    // --- WalletStatus ---
+
+    #[derive(Clone)]
+    pub struct WalletStatus {
+        client: Client,
+    }
+
+    impl Datamaxi for WalletStatus {
+        fn new(api_key: String) -> WalletStatus {
+            let config = Config {
+                base_url: None,
+                api_key,
+            };
+            WalletStatus {
+                client: Client::new(config),
+            }
+        }
+        fn new_with_base_url(api_key: String, base_url: String) -> WalletStatus {
+            let config = Config {
+                base_url: Some(base_url),
+                api_key,
+            };
+            WalletStatus {
+                client: Client::new(config),
+            }
+        }
+    }
+
+    impl WalletStatus {
+        /// Wraps an already-built client (e.g. from `ClientBuilder`).
+        pub fn from_client(client: Client) -> Self {
+            Self { client }
+        }
+
+        /// Get the latest wallet status for asset from given exchange.
+        pub fn get(
+            &self,
+            asset: impl Into<String>,
+            options: WalletStatusOptions,
+        ) -> Result<Vec<WalletStatusView>> {
+            let mut parameters = HashMap::new();
+            parameters.insert("asset".to_string(), asset.into());
+            if let Some(v) = options.exchange {
+                parameters.insert("exchange".to_string(), v.to_string());
+            }
+            self.client.get("/api/v1/wallet-status", Some(parameters))
+        }
+
+        /// Get assets accepted by `/api/v1/wallet-status` endpoint.
+        pub fn assets(&self, exchange: impl Into<String>) -> Result<Vec<String>> {
+            let mut parameters = HashMap::new();
+            parameters.insert("exchange".to_string(), exchange.into());
+            self.client
+                .get("/api/v1/wallet-status/assets", Some(parameters))
+        }
+
+        /// Get exchanges accepted by `/api/v1/wallet-status` endpoint.
+        pub fn exchanges(&self) -> Result<Vec<String>> {
+            self.client.get("/api/v1/wallet-status/exchanges", None)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,10 @@
 //!
 //! ### CEX Candle
 //!
+//! The client is async by default (requires a runtime such as `tokio`). For a
+//! synchronous client, enable the `blocking` feature and use the mirrored
+//! wrappers under `datamaxi::generated::blocking` with `datamaxi::api::blocking`.
+//!
 //! ```no_run
 //! use datamaxi::api::Datamaxi;
 //! use datamaxi::generated::{
@@ -38,19 +42,24 @@
 //!     CexCandleSymbolsOptions,
 //! };
 //!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! let candle: CexCandle = Datamaxi::new("my_api_key".to_string());
 //!
 //! // Supported exchanges, symbols and intervals
-//! let _ = candle.exchanges(CexCandleExchangesMarket::Spot);
-//! let _ = candle.symbols("binance", CexCandleSymbolsOptions::new());
-//! let _ = candle.intervals();
+//! let _ = candle.exchanges(CexCandleExchangesMarket::Spot).await?;
+//! let _ = candle.symbols("binance", CexCandleSymbolsOptions::new()).await?;
+//! let _ = candle.intervals().await?;
 //!
 //! // Fetch CEX candle data
-//! let _ = candle.get(
-//!     "binance",
-//!     "BTC-USDT",
-//!     CexCandleOptions::new().market(CexCandleMarket::Spot),
-//! );
+//! let _ = candle
+//!     .get(
+//!         "binance",
+//!         "BTC-USDT",
+//!         CexCandleOptions::new().market(CexCandleMarket::Spot),
+//!     )
+//!     .await?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Links
@@ -81,7 +90,7 @@ pub mod api;
 ///
 /// let liq: Liquidation = Datamaxi::new("YOUR_API_KEY".into());
 /// let opts = LiquidationHeatmapOptions::new();
-/// let heatmap = liq.heatmap(opts)?;
+/// let heatmap = liq.heatmap(opts).await?;
 /// ```
 // `generated.rs` is code-generated (DO NOT EDIT); these lints reflect the
 // generator's unconditional imports and its `new()`-only option constructors,

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -59,13 +59,14 @@ macro_rules! key_or_skip {
 
 /// `/cex/candle/exchanges` returns a non-empty list including a well-known
 /// exchange. Locks the path, auth, and top-level array shape against prod.
-#[test]
-fn live_cex_candle_exchanges() {
+#[tokio::test]
+async fn live_cex_candle_exchanges() {
     let key = key_or_skip!("live_cex_candle_exchanges");
     let candle: CexCandle = Datamaxi::new(key);
 
     let v = candle
         .exchanges(CexCandleExchangesMarket::Spot)
+        .await
         .expect("live /cex/candle/exchanges request failed");
 
     assert!(!v.is_empty(), "exchange list should not be empty");
@@ -77,8 +78,8 @@ fn live_cex_candle_exchanges() {
 
 /// `/cex/candle` returns an object carrying a `data` array. Locks the primary
 /// candle endpoint and its response envelope against prod.
-#[test]
-fn live_cex_candle_get() {
+#[tokio::test]
+async fn live_cex_candle_get() {
     let key = key_or_skip!("live_cex_candle_get");
     let candle: CexCandle = Datamaxi::new(key);
 
@@ -87,19 +88,21 @@ fn live_cex_candle_get() {
         .interval("1h");
     let v = candle
         .get("binance", "BTC-USDT", opts)
+        .await
         .expect("live /cex/candle request failed");
 
     assert!(!v.data.is_empty(), "candle `data` should not be empty");
 }
 
 /// `/cex/announcements` returns a paginated `data` array of announcements.
-#[test]
-fn live_cex_announcements() {
+#[tokio::test]
+async fn live_cex_announcements() {
     let key = key_or_skip!("live_cex_announcements");
     let ann: Announcements = Datamaxi::new(key);
 
     let resp = ann
         .announcements(CexAnnouncementsOptions::new())
+        .await
         .expect("live /cex/announcements request failed");
 
     assert!(
@@ -110,13 +113,14 @@ fn live_cex_announcements() {
 
 /// `/cex/token/updates` returns a paginated `data` array of listed/delisted
 /// token updates.
-#[test]
-fn live_cex_token_updates() {
+#[tokio::test]
+async fn live_cex_token_updates() {
     let key = key_or_skip!("live_cex_token_updates");
     let token: Token = Datamaxi::new(key);
 
     let resp = token
         .updates(CexTokenUpdatesOptions::new())
+        .await
         .expect("live /cex/token/updates request failed");
 
     assert!(
@@ -126,12 +130,15 @@ fn live_cex_token_updates() {
 }
 
 /// `/forex` echoes the requested `symbol` in the typed response.
-#[test]
-fn live_forex_get() {
+#[tokio::test]
+async fn live_forex_get() {
     let key = key_or_skip!("live_forex_get");
     let forex: Forex = Datamaxi::new(key);
 
-    let resp = forex.get("USD-KRW").expect("live /forex request failed");
+    let resp = forex
+        .get("USD-KRW")
+        .await
+        .expect("live /forex request failed");
 
     assert_eq!(
         resp.symbol, "USD-KRW",
@@ -141,14 +148,15 @@ fn live_forex_get() {
 
 /// `/funding-rate/history` returns a non-empty `data` array for a liquid
 /// perpetual pair.
-#[test]
-fn live_funding_rate_history() {
+#[tokio::test]
+async fn live_funding_rate_history() {
     let key = key_or_skip!("live_funding_rate_history");
     let fr: FundingRate = Datamaxi::new(key);
 
     let opts = FundingRateHistoryOptions::new().limit(5);
     let resp = fr
         .history("binance", "BTC-USDT", opts)
+        .await
         .expect("live /funding-rate/history request failed");
 
     assert!(
@@ -158,13 +166,14 @@ fn live_funding_rate_history() {
 }
 
 /// `/funding-rate/latest` echoes the requested `exchange`.
-#[test]
-fn live_funding_rate_latest() {
+#[tokio::test]
+async fn live_funding_rate_latest() {
     let key = key_or_skip!("live_funding_rate_latest");
     let fr: FundingRate = Datamaxi::new(key);
 
     let resp = fr
         .latest("binance", "BTC-USDT")
+        .await
         .expect("live /funding-rate/latest request failed");
 
     assert_eq!(
@@ -174,13 +183,14 @@ fn live_funding_rate_latest() {
 }
 
 /// `/index-price` returns a non-empty `data` array of price points.
-#[test]
-fn live_index_price_get() {
+#[tokio::test]
+async fn live_index_price_get() {
     let key = key_or_skip!("live_index_price_get");
     let idx: IndexPrice = Datamaxi::new(key);
 
     let resp = idx
         .get("BTC", IndexPriceOptions::new())
+        .await
         .expect("live /index-price request failed");
 
     assert!(
@@ -190,14 +200,15 @@ fn live_index_price_get() {
 }
 
 /// `/liquidation` returns at most `limit` recent liquidation events.
-#[test]
-fn live_liquidation_get() {
+#[tokio::test]
+async fn live_liquidation_get() {
     let key = key_or_skip!("live_liquidation_get");
     let liq: Liquidation = Datamaxi::new(key);
 
     let opts = LiquidationOptions::new().limit(5);
     let resp = liq
         .get("binance", "BTC-USDT", opts)
+        .await
         .expect("live /liquidation request failed");
 
     assert!(
@@ -208,14 +219,15 @@ fn live_liquidation_get() {
 
 /// `/liquidation/feed` returns at most `limit` recent liquidation events
 /// across all symbols.
-#[test]
-fn live_liquidation_feed() {
+#[tokio::test]
+async fn live_liquidation_feed() {
     let key = key_or_skip!("live_liquidation_feed");
     let liq: Liquidation = Datamaxi::new(key);
 
     let opts = LiquidationFeedOptions::new().exchange("binance").limit(5);
     let resp = liq
         .feed(opts)
+        .await
         .expect("live /liquidation/feed request failed");
 
     assert!(
@@ -227,8 +239,8 @@ fn live_liquidation_feed() {
 /// `/liquidation/heatmap` returns an object with a `tokens` array. Also
 /// exercises the `top_n` snake_case wire key over the real API (the PR #8
 /// regression surface).
-#[test]
-fn live_liquidation_heatmap() {
+#[tokio::test]
+async fn live_liquidation_heatmap() {
     let key = key_or_skip!("live_liquidation_heatmap");
     let liq: Liquidation = Datamaxi::new(key);
 
@@ -237,6 +249,7 @@ fn live_liquidation_heatmap() {
         .top_n(3);
     let v = liq
         .heatmap(opts)
+        .await
         .expect("live /liquidation/heatmap request failed");
 
     assert_eq!(
@@ -246,8 +259,8 @@ fn live_liquidation_heatmap() {
 }
 
 /// `/liquidation/map` echoes the requested `exchange` for a liquid pair.
-#[test]
-fn live_liquidation_map() {
+#[tokio::test]
+async fn live_liquidation_map() {
     let key = key_or_skip!("live_liquidation_map");
     let liq: Liquidation = Datamaxi::new(key);
 
@@ -255,7 +268,10 @@ fn live_liquidation_map() {
         .exchange("binance")
         .base("BTC")
         .quote("USDT");
-    let resp = liq.map(opts).expect("live /liquidation/map request failed");
+    let resp = liq
+        .map(opts)
+        .await
+        .expect("live /liquidation/map request failed");
 
     assert_eq!(
         resp.exchange, "binance",
@@ -265,14 +281,15 @@ fn live_liquidation_map() {
 
 /// `/liquidation/stats` echoes the requested `window` (also the `min_volume_usd`
 /// snake_case wire key from the PR #8 regression surface).
-#[test]
-fn live_liquidation_stats() {
+#[tokio::test]
+async fn live_liquidation_stats() {
     let key = key_or_skip!("live_liquidation_stats");
     let liq: Liquidation = Datamaxi::new(key);
 
     let opts = LiquidationStatsOptions::new().window(LiquidationStatsWindow::_24h);
     let resp = liq
         .stats(opts)
+        .await
         .expect("live /liquidation/stats request failed");
 
     assert_eq!(
@@ -282,8 +299,8 @@ fn live_liquidation_stats() {
 }
 
 /// `/liquidation/symbol-history` echoes the requested `symbol` and `window`.
-#[test]
-fn live_liquidation_symbol_history() {
+#[tokio::test]
+async fn live_liquidation_symbol_history() {
     let key = key_or_skip!("live_liquidation_symbol_history");
     let liq: Liquidation = Datamaxi::new(key);
 
@@ -294,6 +311,7 @@ fn live_liquidation_symbol_history() {
         .window(LiquidationSymbolHistoryWindow::_24h);
     let resp = liq
         .symbol_history("BTC", opts)
+        .await
         .expect("live /liquidation/symbol-history request failed");
 
     assert_eq!(
@@ -307,12 +325,12 @@ fn live_liquidation_symbol_history() {
 }
 
 /// `/listings/historical` returns a non-empty `data` array.
-#[test]
-fn live_listings_historical() {
+#[tokio::test]
+async fn live_listings_historical() {
     let key = key_or_skip!("live_listings_historical");
     let listing: Listing = Datamaxi::new(key);
 
-    match listing.historical(ListingsHistoricalOptions::new()) {
+    match listing.historical(ListingsHistoricalOptions::new()).await {
         Ok(resp) => assert!(
             !resp.data.is_empty(),
             "listings historical `data` should not be empty"
@@ -329,12 +347,15 @@ fn live_listings_historical() {
 
 /// `/margin-borrow` returns non-null `cross`/`isolated` objects for a widely
 /// listed asset.
-#[test]
-fn live_margin_borrow_get() {
+#[tokio::test]
+async fn live_margin_borrow_get() {
     let key = key_or_skip!("live_margin_borrow_get");
     let mb: MarginBorrow = Datamaxi::new(key);
 
-    let resp = mb.get("BTC").expect("live /margin-borrow request failed");
+    let resp = mb
+        .get("BTC")
+        .await
+        .expect("live /margin-borrow request failed");
 
     assert!(
         !resp.cross.is_null(),
@@ -343,13 +364,14 @@ fn live_margin_borrow_get() {
 }
 
 /// `/open-interest` echoes the requested `exchange`/`symbol`.
-#[test]
-fn live_open_interest_get() {
+#[tokio::test]
+async fn live_open_interest_get() {
     let key = key_or_skip!("live_open_interest_get");
     let oi: OpenInterest = Datamaxi::new(key);
 
     let resp = oi
         .get("binance", "BTC-USDT")
+        .await
         .expect("live /open-interest request failed");
 
     assert_eq!(
@@ -360,13 +382,14 @@ fn live_open_interest_get() {
 
 /// `/open-interest/history-aggregated` returns token metadata for the
 /// requested `token_id`.
-#[test]
-fn live_open_interest_history_aggregated() {
+#[tokio::test]
+async fn live_open_interest_history_aggregated() {
     let key = key_or_skip!("live_open_interest_history_aggregated");
     let oi: OpenInterest = Datamaxi::new(key);
 
     let resp = oi
         .history_aggregated("bitcoin", OpenInterestHistoryAggregatedOptions::new())
+        .await
         .expect("live /open-interest/history-aggregated request failed");
 
     assert_eq!(
@@ -376,14 +399,15 @@ fn live_open_interest_history_aggregated() {
 }
 
 /// `/open-interest/list` returns a non-empty `data` array.
-#[test]
-fn live_open_interest_list() {
+#[tokio::test]
+async fn live_open_interest_list() {
     let key = key_or_skip!("live_open_interest_list");
     let oi: OpenInterest = Datamaxi::new(key);
 
     let opts = OpenInterestListOptions::new().exchange("binance");
     let resp = oi
         .list(opts)
+        .await
         .expect("live /open-interest/list request failed");
 
     assert!(
@@ -393,13 +417,14 @@ fn live_open_interest_list() {
 }
 
 /// `/open-interest/overview` returns a non-empty `data` array.
-#[test]
-fn live_open_interest_overview() {
+#[tokio::test]
+async fn live_open_interest_overview() {
     let key = key_or_skip!("live_open_interest_overview");
     let oi: OpenInterest = Datamaxi::new(key);
 
     let resp = oi
         .overview(OpenInterestOverviewOptions::new())
+        .await
         .expect("live /open-interest/overview request failed");
 
     assert!(
@@ -410,14 +435,15 @@ fn live_open_interest_overview() {
 
 /// `/open-interest/summary` returns a non-empty `tokens` array. Also exercises
 /// the `top_n` snake_case wire key from the PR #8 regression surface.
-#[test]
-fn live_open_interest_summary() {
+#[tokio::test]
+async fn live_open_interest_summary() {
     let key = key_or_skip!("live_open_interest_summary");
     let oi: OpenInterest = Datamaxi::new(key);
 
     let opts = OpenInterestSummaryOptions::new().top_n(5);
     let resp = oi
         .summary(opts)
+        .await
         .expect("live /open-interest/summary request failed");
 
     assert!(
@@ -427,12 +453,12 @@ fn live_open_interest_summary() {
 }
 
 /// `/premium` returns a non-empty `data` array with default pagination.
-#[test]
-fn live_premium_get() {
+#[tokio::test]
+async fn live_premium_get() {
     let key = key_or_skip!("live_premium_get");
     let premium: Premium = Datamaxi::new(key);
 
-    match premium.get(PremiumOptions::new().limit(10)) {
+    match premium.get(PremiumOptions::new().limit(10)).await {
         Ok(resp) => assert!(!resp.data.is_empty(), "premium `data` should not be empty"),
         // `sc`/`tc`/`spa`/`tpa` (String) are now Option; but `PremiumDetail`
         // also has conditionally-present numeric (f64) fields that are null
@@ -446,13 +472,14 @@ fn live_premium_get() {
 
 /// `/telegram/channels` returns a non-empty `data` array with default
 /// pagination.
-#[test]
-fn live_telegram_channels() {
+#[tokio::test]
+async fn live_telegram_channels() {
     let key = key_or_skip!("live_telegram_channels");
     let tg: Telegram = Datamaxi::new(key);
 
     let resp = tg
         .channels(TelegramChannelsOptions::new())
+        .await
         .expect("live /telegram/channels request failed");
     assert!(
         !resp.data.is_empty(),
@@ -462,13 +489,14 @@ fn live_telegram_channels() {
 
 /// `/telegram/messages` returns a non-empty `data` array with default
 /// pagination.
-#[test]
-fn live_telegram_messages() {
+#[tokio::test]
+async fn live_telegram_messages() {
     let key = key_or_skip!("live_telegram_messages");
     let tg: Telegram = Datamaxi::new(key);
 
     let resp = tg
         .messages(TelegramMessagesOptions::new())
+        .await
         .expect("live /telegram/messages request failed");
 
     assert!(
@@ -478,8 +506,8 @@ fn live_telegram_messages() {
 }
 
 /// `/ticker` echoes the requested `symbol` in the nested typed `data` view.
-#[test]
-fn live_ticker_get() {
+#[tokio::test]
+async fn live_ticker_get() {
     let key = key_or_skip!("live_ticker_get");
     let ticker: Ticker = Datamaxi::new(key);
 
@@ -490,6 +518,7 @@ fn live_ticker_get() {
             TickerMarket::Spot,
             TickerOptions::new(),
         )
+        .await
         .expect("live /ticker request failed");
 
     assert_eq!(

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -24,9 +24,9 @@ const API_KEY: &str = "test-api-key";
 
 /// `top_n` wire key (regression guard for PR #8) + `window`, plus path and the
 /// `X-DTMX-APIKEY` auth header.
-#[test]
-fn liquidation_heatmap_sends_top_n_window_and_apikey() {
-    let mut server = mockito::Server::new();
+#[tokio::test]
+async fn liquidation_heatmap_sends_top_n_window_and_apikey() {
+    let mut server = mockito::Server::new_async().await;
 
     let mock = server
         .mock("GET", "/api/v1/liquidation/heatmap")
@@ -39,22 +39,23 @@ fn liquidation_heatmap_sends_top_n_window_and_apikey() {
         .with_header("content-type", "application/json")
         .with_body("{}")
         .expect(1)
-        .create();
+        .create_async()
+        .await;
 
     let liq: Liquidation = Datamaxi::new_with_base_url(API_KEY.to_string(), server.url());
     let opts = LiquidationHeatmapOptions::new()
         .window(LiquidationHeatmapWindow::_1h)
         .top_n(10);
-    let res = liq.heatmap(opts);
+    let res = liq.heatmap(opts).await;
 
-    mock.assert();
+    mock.assert_async().await;
     assert!(res.is_ok(), "expected Ok, got {:?}", res);
 }
 
 /// `min_volume_usd` wire key (regression guard for PR #8) on the stats endpoint.
-#[test]
-fn liquidation_stats_sends_min_volume_usd() {
-    let mut server = mockito::Server::new();
+#[tokio::test]
+async fn liquidation_stats_sends_min_volume_usd() {
+    let mut server = mockito::Server::new_async().await;
 
     let mock = server
         .mock("GET", "/api/v1/liquidation/stats")
@@ -66,22 +67,23 @@ fn liquidation_stats_sends_min_volume_usd() {
         .with_status(200)
         .with_body("{}")
         .expect(1)
-        .create();
+        .create_async()
+        .await;
 
     let liq: Liquidation = Datamaxi::new_with_base_url(API_KEY.to_string(), server.url());
     let opts = LiquidationStatsOptions::new()
         .window(LiquidationStatsWindow::_24h)
         .min_volume_usd(5.0);
-    let res = liq.stats(opts);
+    let res = liq.stats(opts).await;
 
-    mock.assert();
+    mock.assert_async().await;
     assert!(res.is_ok(), "expected Ok, got {:?}", res);
 }
 
 /// CEX candle: required path params + several optional query keys/values.
-#[test]
-fn cex_candle_sends_required_and_optional_keys() {
-    let mut server = mockito::Server::new();
+#[tokio::test]
+async fn cex_candle_sends_required_and_optional_keys() {
+    let mut server = mockito::Server::new_async().await;
 
     let mock = server
         .mock("GET", "/api/v1/cex/candle")
@@ -96,16 +98,17 @@ fn cex_candle_sends_required_and_optional_keys() {
         .with_status(200)
         .with_body("{}")
         .expect(1)
-        .create();
+        .create_async()
+        .await;
 
     let candle: CexCandle = Datamaxi::new_with_base_url(API_KEY.to_string(), server.url());
     let opts = CexCandleOptions::new()
         .market(CexCandleMarket::Spot)
         .interval("1h")
         .currency(CexCandleCurrency::USD);
-    let res = candle.get("binance", "BTC-USDT", opts);
+    let res = candle.get("binance", "BTC-USDT", opts).await;
 
-    mock.assert();
+    mock.assert_async().await;
     assert!(res.is_ok(), "expected Ok, got {:?}", res);
 }
 
@@ -114,9 +117,9 @@ fn cex_candle_sends_required_and_optional_keys() {
 /// incoming query before comparing, so a match proves the raw value was encoded
 /// and round-trips. A pre-fix hand-rolled `k=v` join would emit the raw `&`,
 /// `=`, space and `\u{e9}`, corrupting the query string and failing this match.
-#[test]
-fn query_params_are_percent_encoded() {
-    let mut server = mockito::Server::new();
+#[tokio::test]
+async fn query_params_are_percent_encoded() {
+    let mut server = mockito::Server::new_async().await;
 
     // Contains `&`, `=`, a space and a non-ASCII char.
     let raw_symbol = "A&B=C D\u{e9}";
@@ -133,47 +136,53 @@ fn query_params_are_percent_encoded() {
         .with_header("content-type", "application/json")
         .with_body("{}")
         .expect(1)
-        .create();
+        .create_async()
+        .await;
 
     let candle: CexCandle = Datamaxi::new_with_base_url(API_KEY.to_string(), server.url());
-    let res = candle.get(
-        "binance",
-        raw_symbol,
-        CexCandleOptions::new().market(CexCandleMarket::Spot),
-    );
+    let res = candle
+        .get(
+            "binance",
+            raw_symbol,
+            CexCandleOptions::new().market(CexCandleMarket::Spot),
+        )
+        .await;
 
-    mock.assert();
+    mock.assert_async().await;
     assert!(res.is_ok(), "expected Ok, got {:?}", res);
 }
 
 // --- handle_response status mapping ---------------------------------------
 
-fn call_with_status(
+async fn call_with_status(
     status: usize,
     body: &str,
 ) -> datamaxi::api::Result<LiquidationHeatmapResponse> {
-    let mut server = mockito::Server::new();
+    let mut server = mockito::Server::new_async().await;
     let _mock = server
         .mock("GET", "/api/v1/liquidation/heatmap")
         .with_status(status)
         .with_body(body)
-        .create();
+        .create_async()
+        .await;
 
     let liq: Liquidation = Datamaxi::new_with_base_url(API_KEY.to_string(), server.url());
-    liq.heatmap(LiquidationHeatmapOptions::new())
+    liq.heatmap(LiquidationHeatmapOptions::new()).await
 }
 
-#[test]
-fn status_200_maps_to_ok() {
+#[tokio::test]
+async fn status_200_maps_to_ok() {
     // Body deserializes into the typed `LiquidationHeatmapResponse`; struct-level
     // serde default lets an empty `{}` payload decode with zero-valued fields.
-    let res = call_with_status(200, "{}");
+    let res = call_with_status(200, "{}").await;
     assert!(res.is_ok(), "200 should map to Ok, got {:?}", res);
 }
 
-#[test]
-fn status_400_maps_to_bad_request() {
-    let err = call_with_status(400, "bad input").expect_err("400 should be Err");
+#[tokio::test]
+async fn status_400_maps_to_bad_request() {
+    let err = call_with_status(400, "bad input")
+        .await
+        .expect_err("400 should be Err");
     assert!(
         matches!(err, Error::BadRequest(_)),
         "400 should map to BadRequest, got {:?}",
@@ -181,9 +190,11 @@ fn status_400_maps_to_bad_request() {
     );
 }
 
-#[test]
-fn status_401_maps_to_unauthorized() {
-    let err = call_with_status(401, "").expect_err("401 should be Err");
+#[tokio::test]
+async fn status_401_maps_to_unauthorized() {
+    let err = call_with_status(401, "")
+        .await
+        .expect_err("401 should be Err");
     assert!(
         matches!(err, Error::Unauthorized),
         "401 should map to Unauthorized, got {:?}",
@@ -191,9 +202,11 @@ fn status_401_maps_to_unauthorized() {
     );
 }
 
-#[test]
-fn status_500_maps_to_internal_server_error() {
-    let err = call_with_status(500, "boom").expect_err("500 should be Err");
+#[tokio::test]
+async fn status_500_maps_to_internal_server_error() {
+    let err = call_with_status(500, "boom")
+        .await
+        .expect_err("500 should be Err");
     assert!(
         matches!(err, Error::InternalServerError(_)),
         "500 should map to InternalServerError, got {:?}",
@@ -201,9 +214,11 @@ fn status_500_maps_to_internal_server_error() {
     );
 }
 
-#[test]
-fn status_404_maps_to_unexpected_status_code() {
-    let err = call_with_status(404, "nope").expect_err("404 should be Err");
+#[tokio::test]
+async fn status_404_maps_to_unexpected_status_code() {
+    let err = call_with_status(404, "nope")
+        .await
+        .expect_err("404 should be Err");
     assert!(
         matches!(err, Error::UnexpectedStatusCode(404)),
         "404 should map to UnexpectedStatusCode(404), got {:?}",
@@ -222,9 +237,9 @@ fn status_404_maps_to_unexpected_status_code() {
 /// `/api/v1/open-interest/summary`: the `top_n` builder must serialize to the
 /// `top_n` wire key — the same camelCase→snake_case case PR #8 got wrong on
 /// liquidation.
-#[test]
-fn open_interest_summary_sends_top_n() {
-    let mut server = mockito::Server::new();
+#[tokio::test]
+async fn open_interest_summary_sends_top_n() {
+    let mut server = mockito::Server::new_async().await;
 
     let mock = server
         .mock("GET", "/api/v1/open-interest/summary")
@@ -234,20 +249,21 @@ fn open_interest_summary_sends_top_n() {
         .with_header("content-type", "application/json")
         .with_body("{}")
         .expect(1)
-        .create();
+        .create_async()
+        .await;
 
     let oi: OpenInterest = Datamaxi::new_with_base_url(API_KEY.to_string(), server.url());
-    let res = oi.summary(OpenInterestSummaryOptions::new().top_n(5));
+    let res = oi.summary(OpenInterestSummaryOptions::new().top_n(5)).await;
 
-    mock.assert();
+    mock.assert_async().await;
     assert!(res.is_ok(), "expected Ok, got {:?}", res);
 }
 
 /// `/cex/symbol/cautions`: multi-word snake_case keys `min_level` and
 /// `active_only` (bool) round-trip on the wire.
-#[test]
-fn cex_symbol_cautions_sends_snake_keys() {
-    let mut server = mockito::Server::new();
+#[tokio::test]
+async fn cex_symbol_cautions_sends_snake_keys() {
+    let mut server = mockito::Server::new_async().await;
 
     let mock = server
         .mock("GET", "/api/v1/cex/symbol/cautions")
@@ -262,24 +278,25 @@ fn cex_symbol_cautions_sends_snake_keys() {
         // `/cex/symbol/cautions` returns a top-level array (Vec<..>).
         .with_body("[]")
         .expect(1)
-        .create();
+        .create_async()
+        .await;
 
     let sym: CexSymbol = Datamaxi::new_with_base_url(API_KEY.to_string(), server.url());
     let opts = CexSymbolCautionsOptions::new()
         .exchange("binance")
         .min_level(CexSymbolCautionsMinLevel::Danger)
         .active_only(true);
-    let res = sym.cautions(opts);
+    let res = sym.cautions(opts).await;
 
-    mock.assert();
+    mock.assert_async().await;
     assert!(res.is_ok(), "expected Ok, got {:?}", res);
 }
 
 /// `/premium`: several multi-word snake_case keys (`source_exchange`,
 /// `target_exchange`, `premium_type`) and the `/api/v1`-prefixed path.
-#[test]
-fn premium_sends_snake_keys() {
-    let mut server = mockito::Server::new();
+#[tokio::test]
+async fn premium_sends_snake_keys() {
+    let mut server = mockito::Server::new_async().await;
 
     let mock = server
         .mock("GET", "/api/v1/premium")
@@ -293,16 +310,17 @@ fn premium_sends_snake_keys() {
         .with_header("content-type", "application/json")
         .with_body("{}")
         .expect(1)
-        .create();
+        .create_async()
+        .await;
 
     let premium: Premium = Datamaxi::new_with_base_url(API_KEY.to_string(), server.url());
     let opts = PremiumOptions::new()
         .source_exchange("binance")
         .target_exchange("upbit")
         .premium_type(PremiumPremiumType::SpotFutures);
-    let res = premium.get(opts);
+    let res = premium.get(opts).await;
 
-    mock.assert();
+    mock.assert_async().await;
     assert!(res.is_ok(), "expected Ok, got {:?}", res);
 }
 
@@ -310,9 +328,10 @@ fn premium_sends_snake_keys() {
 
 /// A `Client` built via `ClientBuilder` sends the `datamaxi-rust/<ver>`
 /// User-Agent and the auth header, and routes requests through the same path.
-#[test]
-fn client_builder_sets_user_agent_and_auth() {
-    let mut server = mockito::Server::new();
+/// Also exercises `from_client`, which wraps a pre-built client.
+#[tokio::test]
+async fn client_builder_sets_user_agent_and_auth() {
+    let mut server = mockito::Server::new_async().await;
 
     let mock = server
         .mock("GET", "/api/v1/cex/candle/exchanges")
@@ -327,17 +346,18 @@ fn client_builder_sets_user_agent_and_auth() {
         // `/cex/candle/exchanges` returns a top-level array (Vec<String>).
         .with_body("[]")
         .expect(1)
-        .create();
+        .create_async()
+        .await;
 
     let client = ClientBuilder::new()
         .api_key(API_KEY)
         .base_url(server.url())
         .build()
         .expect("explicit api key should build");
-    let candle = CexCandle { client };
-    let res = candle.exchanges(CexCandleExchangesMarket::Spot);
+    let candle = CexCandle::from_client(client);
+    let res = candle.exchanges(CexCandleExchangesMarket::Spot).await;
 
-    mock.assert();
+    mock.assert_async().await;
     assert!(res.is_ok(), "expected Ok, got {:?}", res);
 }
 
@@ -354,4 +374,56 @@ fn client_builder_without_key_errors() {
         "expected MissingApiKey, got {:?}",
         err
     );
+}
+
+// --- Blocking feature smoke tests ------------------------------------------
+
+/// The `blocking` mirror exposes the same endpoints synchronously and routes
+/// through `crate::api::blocking::Client`.
+#[cfg(feature = "blocking")]
+#[test]
+fn blocking_cex_candle_exchanges_smoke() {
+    use datamaxi::generated::blocking::CexCandle as BlockingCexCandle;
+
+    let mut server = mockito::Server::new();
+    let mock = server
+        .mock("GET", "/api/v1/cex/candle/exchanges")
+        .match_header("X-DTMX-APIKEY", API_KEY)
+        .match_query(Matcher::UrlEncoded("market".into(), "spot".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("[]")
+        .expect(1)
+        .create();
+
+    let candle: BlockingCexCandle = Datamaxi::new_with_base_url(API_KEY.to_string(), server.url());
+    let res = candle.exchanges(CexCandleExchangesMarket::Spot);
+
+    mock.assert();
+    assert!(res.is_ok(), "expected Ok, got {:?}", res);
+}
+
+/// Blocking mirror decodes a typed object response and maps status errors the
+/// same way as the async surface.
+#[cfg(feature = "blocking")]
+#[test]
+fn blocking_liquidation_heatmap_smoke() {
+    use datamaxi::generated::blocking::Liquidation as BlockingLiquidation;
+
+    let mut server = mockito::Server::new();
+    let mock = server
+        .mock("GET", "/api/v1/liquidation/heatmap")
+        .match_header("X-DTMX-APIKEY", API_KEY)
+        .match_query(Matcher::UrlEncoded("window".into(), "1h".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("{}")
+        .expect(1)
+        .create();
+
+    let liq: BlockingLiquidation = Datamaxi::new_with_base_url(API_KEY.to_string(), server.url());
+    let res = liq.heatmap(LiquidationHeatmapOptions::new().window(LiquidationHeatmapWindow::_1h));
+
+    mock.assert();
+    assert!(res.is_ok(), "expected Ok, got {:?}", res);
 }


### PR DESCRIPTION
## Summary

Makes the SDK **async-first** (Approach B, agreed design): async by default with an opt-in `blocking` feature — mirroring reqwest's own model. Paired generator change: https://github.com/Bisonai/datamaxi-codegen/pull/61.

- **Async by default**: every endpoint method is `async fn` returning a Future; needs a runtime (e.g. `tokio`). `reqwest` default drops the `blocking` feature.
- **`blocking` feature**: restores a synchronous surface — `datamaxi::api::blocking::{Client, ClientBuilder}` + `datamaxi::generated::blocking::*` (a mirror of the endpoint wrappers), same status→`Error` mapping. For scripts/notebooks without an async runtime.
- **Encapsulation**: the generated endpoint struct `client` field is now private; construct via `Datamaxi::new*` or the new `from_client(client)`.
- **Deferred** (out of scope, noted in #39): the `Datamaxi`-trait → root-accessor redesign.
- **Breaking** (`0.9.0` → `0.10.0`): all endpoint methods are async; `client` field private.

### Non-local changes
- `tests/wire_contract.rs`, `tests/live.rs`: `#[tokio::test]` + `.await`, async `mockito`; 2 new `#[cfg(feature="blocking")]` smoke tests; `from_client` exercised.
- `examples/cex-candle.rs`: `#[tokio::main]`; `src/lib.rs` + `README.md`: async usage + `blocking` note.

## Tests
- `cargo fmt --all -- --check` — clean; regenerated `generated.rs` is byte-identical to the emitter output (drift-guard safe).
- `cargo clippy --all-targets -- -D warnings` and `--features blocking` — both clean.
- `cargo test --all-targets` (async) — wire 14/14, live **24/25** vs prod (`live_forex_get` is a concurrent-load flake — passes in isolation; live-suite property, not an async bug).
- `cargo test --features blocking` — wire+blocking 16/16. Doctests 2/2.

## Known
- The one live flake above (parallel real-API load). Merge alongside the codegen PR.