### PR TITLE
feat: re-export endpoint types at crate root (drop `generated` path)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datamaxi"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 readme = "README.md"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 The client is **async** by default and needs an async runtime (e.g. `tokio`).
 For a synchronous client, enable the `blocking` feature and use the mirrored
-wrappers under `datamaxi::generated::blocking`:
+wrappers under `datamaxi::blocking`:
 
 ```toml
 [dependencies]
@@ -41,7 +41,7 @@ Set `DATAMAXI_API_KEY` to avoid passing the key inline.
 
 ```rust
 use datamaxi::api::Datamaxi;
-use datamaxi::generated::{
+use datamaxi::{
     CexCandle, CexCandleExchangesMarket, CexCandleMarket, CexCandleOptions,
     CexCandleSymbolsOptions,
 };
@@ -65,7 +65,7 @@ candle
 ```
 
 With the `blocking` feature the same calls are synchronous (no `.await`), via
-`datamaxi::generated::blocking::CexCandle` and `datamaxi::api::blocking`.
+`datamaxi::blocking::CexCandle` and `datamaxi::api::blocking`.
 
 Data endpoints deserialize into typed response structs generated from the API
 spec: object responses into a struct (e.g. `candle.get(..)` → `CexCandleResponse`)

--- a/examples/cex-candle.rs
+++ b/examples/cex-candle.rs
@@ -1,5 +1,5 @@
 use datamaxi::api::Datamaxi;
-use datamaxi::generated::{
+use datamaxi::{
     CexCandle, CexCandleExchangesMarket, CexCandleMarket, CexCandleOptions, CexCandleSymbolsOptions,
 };
 use std::env;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,11 +33,11 @@
 //!
 //! The client is async by default (requires a runtime such as `tokio`). For a
 //! synchronous client, enable the `blocking` feature and use the mirrored
-//! wrappers under `datamaxi::generated::blocking` with `datamaxi::api::blocking`.
+//! wrappers under `datamaxi::blocking` with `datamaxi::api::blocking`.
 //!
 //! ```no_run
 //! use datamaxi::api::Datamaxi;
-//! use datamaxi::generated::{
+//! use datamaxi::{
 //!     CexCandle, CexCandleExchangesMarket, CexCandleMarket, CexCandleOptions,
 //!     CexCandleSymbolsOptions,
 //! };
@@ -79,22 +79,25 @@
 /// API definitions and related utilities.
 pub mod api;
 
-/// Auto-generated typed wrappers for every public REST endpoint on the data
-/// API. This is the canonical surface for every endpoint group (CEX candle,
-/// OI, Liquidation, cex-symbol, …).
-///
-/// Usage:
-/// ```ignore
-/// use datamaxi::api::Datamaxi;
-/// use datamaxi::generated::{Liquidation, LiquidationHeatmapOptions};
-///
-/// let liq: Liquidation = Datamaxi::new("YOUR_API_KEY".into());
-/// let opts = LiquidationHeatmapOptions::new();
-/// let heatmap = liq.heatmap(opts).await?;
-/// ```
-// `generated.rs` is code-generated (DO NOT EDIT); these lints reflect the
-// generator's unconditional imports and its `new()`-only option constructors,
-// so they are suppressed at the module boundary rather than hand-edited in
-// generated output.
+// `generated.rs` is code-generated (DO NOT EDIT). Its contents are re-exported
+// at the crate root (below), so callers write `datamaxi::CexCandle` rather than
+// through this module path. Hidden from the docs but kept `pub` for backward
+// compatibility. The lint allows reflect the generator's unconditional imports
+// and its `new()`-only option constructors.
+#[doc(hidden)]
 #[allow(unused_imports, clippy::new_without_default)]
 pub mod generated;
+
+/// Typed wrappers for every REST endpoint on the data API — the canonical
+/// surface (CEX candle, OI, Liquidation, cex-symbol, …). Async by default; with
+/// the `blocking` feature, a parallel [`blocking`] module offers synchronous
+/// equivalents.
+///
+/// ```ignore
+/// use datamaxi::api::Datamaxi;
+/// use datamaxi::{Liquidation, LiquidationHeatmapOptions};
+///
+/// let liq: Liquidation = Datamaxi::new("YOUR_API_KEY".into());
+/// let heatmap = liq.heatmap(LiquidationHeatmapOptions::new()).await?;
+/// ```
+pub use generated::*;

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -23,7 +23,7 @@
 //! ```
 
 use datamaxi::api::{Datamaxi, Error};
-use datamaxi::generated::{
+use datamaxi::{
     Announcements, CexAnnouncementsOptions, CexCandle, CexCandleExchangesMarket, CexCandleMarket,
     CexCandleOptions, CexTokenUpdatesOptions, Forex, FundingRate, FundingRateHistoryOptions,
     IndexPrice, IndexPriceOptions, Liquidation, LiquidationFeedOptions, LiquidationHeatmapOptions,

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -11,7 +11,7 @@
 //! if a future codegen regen reintroduces that bug.
 
 use datamaxi::api::{ClientBuilder, Datamaxi, Error};
-use datamaxi::generated::{
+use datamaxi::{
     CexCandle, CexCandleCurrency, CexCandleExchangesMarket, CexCandleMarket, CexCandleOptions,
     CexSymbol, CexSymbolCautionsMinLevel, CexSymbolCautionsOptions, Liquidation,
     LiquidationHeatmapOptions, LiquidationHeatmapResponse, LiquidationHeatmapWindow,
@@ -383,7 +383,7 @@ fn client_builder_without_key_errors() {
 #[cfg(feature = "blocking")]
 #[test]
 fn blocking_cex_candle_exchanges_smoke() {
-    use datamaxi::generated::blocking::CexCandle as BlockingCexCandle;
+    use datamaxi::blocking::CexCandle as BlockingCexCandle;
 
     let mut server = mockito::Server::new();
     let mock = server
@@ -408,7 +408,7 @@ fn blocking_cex_candle_exchanges_smoke() {
 #[cfg(feature = "blocking")]
 #[test]
 fn blocking_liquidation_heatmap_smoke() {
-    use datamaxi::generated::blocking::Liquidation as BlockingLiquidation;
+    use datamaxi::blocking::Liquidation as BlockingLiquidation;
 
     let mut server = mockito::Server::new();
     let mock = server


### PR DESCRIPTION
## Summary

`generated` is a codegen implementation detail that was leaking into the public API — users had to write `datamaxi::generated::CexCandle`. This re-exports everything at the crate root:

- `use datamaxi::{CexCandle, CexCandleOptions};` (was `datamaxi::generated::{…}`)
- `datamaxi::blocking::CexCandle` (was `datamaxi::generated::blocking::…`)
- The `generated` module is now `#[doc(hidden)]`.

**Non-breaking**: the old `datamaxi::generated::` path still resolves (kept `pub`), so existing code compiles. Docs, README, examples, and tests updated to the flat path. Patch bump `0.10.0` → `0.10.1`.

## Tests
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (default **and** `--features blocking`) — clean
- wire 14/14 (async) + 16/16 (blocking); doctests 2/2 (the doc example now uses the flat path)