### PR TITLE
ci: run live tests single-threaded

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -31,7 +31,7 @@ jobs:
       - name: cargo test --test live
         env:
           DATAMAXI_API_KEY: ${{ secrets.DATAMAXI_API_KEY }}
-        run: cargo test --test live
+        run: cargo test --test live -- --test-threads=1
 
   # The live job runs unattended on a schedule, so a red run (expired/missing
   # key, endpoint drift, etc.) could go unnoticed. On failure, open or update a


### PR DESCRIPTION
Closes #48

## What changed
`.github/workflows/live.yml`: the scheduled live job now runs `cargo test --test live -- --test-threads=1` instead of the default parallel invocation.

`live_forex_get` flakes under concurrent load against prod (rate-limit / ordering) but passes in isolation — not an SDK bug. Serializing the live suite in CI removes the concurrency-induced flake. Local runs are unaffected (can still run parallel).

## Test plan
- Workflow-yaml-only change; no Rust code touched.
- Cannot run the live suite here (needs prod API key/secrets). Correctness verified by inspecting the rendered command.
- Next scheduled/manual live run will exercise it single-threaded against prod.