### PR TITLE
ci: dedup rust.yml runs by scoping push to main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,7 @@ name: Rust
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 env:


### PR DESCRIPTION
Closes #52

rust.yml triggered on both `push` and `pull_request` with no branch filters, so every push to a PR branch ran format/lint/test twice (6 jobs instead of 3). This scopes `push` to `[main]` so PR branches run once via `pull_request`, while direct pushes/merges to `main` still get tested. `pull_request` left unfiltered.

Verified: diff is a single added line; `rust.yml` reviewed for correct indentation.