### PR TITLE
ci: add concurrency guard to docs.yml to prevent racing Pages deploys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #58

## Summary
Add top-level `concurrency` block to `.github/workflows/docs.yml` so a newer run cancels the in-flight one before it pushes to `gh-pages`. Back-to-back merges to main were racing GitHub's `pages-build-deployment`, leaving Pages `errored`. Group `pages` + `cancel-in-progress: true` collapses double pushes into a single deploy.

## Test plan
- YAML validated (`yaml.safe_load`) — well-formed.
- Pure CI-config change; no Rust code affected.
- Verify: two rapid merges to main no longer produce a failed `pages-build-deployment` run.