### PR TITLE
Sync generated.rs with backend spec

### DIFF
--- a/src/generated.rs
+++ b/src/generated.rs
@@ -358,9 +358,6 @@ pub struct FundingRateLatestResponse {
     /// Specifies the token id
     #[serde(rename = "id")]
     pub token_id: String,
-    /// Specifies the processed at
-    #[serde(rename = "p")]
-    pub processed_at: i64,
     /// Specifies the quote
     #[serde(rename = "q")]
     pub quote: String,


### PR DESCRIPTION
Automated codegen sync from **datamaxi-codegen**.

The committed `src/generated.rs` had drifted from the current
`Bisonai/datamaxi-backend` OpenAPI spec. This PR regenerates it via
`make update-rust`.

Triggering codegen run:
https://github.com/Bisonai/datamaxi-codegen/actions/runs/28737515273

Do not edit `src/generated.rs` by hand — it is generated. Re-run the
codegen workflow to refresh.