### PR TITLE
ci: lint + test the blocking feature (--all-features)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo clippy --all-targets --all-features -- -D warnings
 
   fmt:
     name: format
@@ -38,3 +38,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-targets
+      - run: cargo test --all-targets --all-features


### PR DESCRIPTION
## Summary

The `blocking` feature was never compiled, linted, or tested in CI, so it could break silently while CI stayed green.

- clippy: `--all-targets -- -D warnings` -> `--all-targets --all-features -- -D warnings`, so blocking code (src/api.rs, src/generated.rs) is now linted under `-D warnings`.
- test: added a second step `cargo test --all-targets --all-features` alongside the existing default run, so the `#[cfg(feature="blocking")]` wire_contract tests compile and run. Both default and blocking paths are exercised.

## Test plan

Locally in the worktree, all green:
- `cargo build` / `cargo build --features blocking`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features --all-targets` — 17 tests pass, including `blocking_cex_candle_exchanges_smoke` and `blocking_liquidation_heatmap_smoke`.

Closes #62