### PR TITLE
feat: map 429/403/404 HTTP statuses + honor Retry-After

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -33,6 +33,17 @@ fn truncate_body(mut s: String) -> String {
     s
 }
 
+/// Parse a `Retry-After` header into a [`Duration`].
+///
+/// Only the numeric delay-seconds form (RFC 9110 §10.2.3) is understood; the
+/// alternative HTTP-date form yields `None` rather than panicking. A missing,
+/// non-ASCII, or unparseable header also yields `None`.
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    let value = headers.get(reqwest::header::RETRY_AFTER)?;
+    let secs = value.to_str().ok()?.trim().parse::<u64>().ok()?;
+    Some(Duration::from_secs(secs))
+}
+
 /// Build the underlying async HTTP client with our defaults (timeout,
 /// `User-Agent`, unbounded idle pool). Falls back to a default client if the
 /// builder fails, so client construction is infallible and never panics.
@@ -113,6 +124,11 @@ async fn handle_response<T: DeserializeOwned>(response: reqwest::Response) -> Re
             Err(Error::InternalServerError(truncate_body(body)))
         }
         StatusCode::UNAUTHORIZED => Err(Error::Unauthorized),
+        StatusCode::FORBIDDEN => Err(Error::Forbidden),
+        StatusCode::NOT_FOUND => Err(Error::NotFound),
+        StatusCode::TOO_MANY_REQUESTS => Err(Error::RateLimited {
+            retry_after: parse_retry_after(response.headers()),
+        }),
         StatusCode::BAD_REQUEST => {
             let body = response.text().await.unwrap_or_default();
             Err(Error::BadRequest(truncate_body(body)))
@@ -223,6 +239,24 @@ pub enum Error {
     #[error("Unauthorized")]
     Unauthorized,
 
+    /// The API returned a `403 Forbidden` (the key is valid but lacks access to the resource).
+    #[error("Forbidden")]
+    Forbidden,
+
+    /// The API returned a `404 Not Found` (the resource or endpoint does not exist).
+    #[error("Not found")]
+    NotFound,
+
+    /// The API returned a `429 Too Many Requests` (rate limited).
+    ///
+    /// `retry_after` carries the `Retry-After` header when present and expressed
+    /// as a delay in seconds; the HTTP-date form is not parsed and yields `None`.
+    #[error("Rate limited")]
+    RateLimited {
+        /// Suggested wait before retrying, from the `Retry-After` header.
+        retry_after: Option<Duration>,
+    },
+
     /// The API returned a `500 Internal Server Error`; the payload carries the server message.
     #[error("Internal server error: {0}")]
     InternalServerError(String),
@@ -247,7 +281,10 @@ pub enum Error {
 /// generated endpoint wrappers under [`crate::generated::blocking`] use this.
 #[cfg(feature = "blocking")]
 pub mod blocking {
-    use super::{truncate_body, user_agent, Error, Result, API_KEY_ENV, BASE_URL, DEFAULT_TIMEOUT};
+    use super::{
+        parse_retry_after, truncate_body, user_agent, Error, Result, API_KEY_ENV, BASE_URL,
+        DEFAULT_TIMEOUT,
+    };
     use reqwest::blocking::Response;
     use reqwest::StatusCode;
     use serde::de::DeserializeOwned;
@@ -330,6 +367,11 @@ pub mod blocking {
                 Err(Error::InternalServerError(truncate_body(body)))
             }
             StatusCode::UNAUTHORIZED => Err(Error::Unauthorized),
+            StatusCode::FORBIDDEN => Err(Error::Forbidden),
+            StatusCode::NOT_FOUND => Err(Error::NotFound),
+            StatusCode::TOO_MANY_REQUESTS => Err(Error::RateLimited {
+                retry_after: parse_retry_after(response.headers()),
+            }),
             StatusCode::BAD_REQUEST => {
                 let mut body = String::new();
                 response.take(1000).read_to_string(&mut body)?;

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -278,12 +278,7 @@ async fn status_429_maps_to_rate_limited_without_retry_after() {
         .await
         .expect_err("429 should be Err");
     assert!(
-        matches!(
-            err,
-            Error::RateLimited {
-                retry_after: None
-            }
-        ),
+        matches!(err, Error::RateLimited { retry_after: None }),
         "429 without Retry-After should map to RateLimited {{ retry_after: None }}, got {:?}",
         err
     );

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -258,6 +258,20 @@ async fn status_404_maps_to_not_found() {
     );
 }
 
+/// An unmapped status (here `502`) still falls through to the catch-all
+/// `UnexpectedStatusCode`, carrying the raw code.
+#[tokio::test]
+async fn status_502_maps_to_unexpected_status_code() {
+    let err = call_with_status(502, "bad gateway")
+        .await
+        .expect_err("502 should be Err");
+    assert!(
+        matches!(err, Error::UnexpectedStatusCode(502)),
+        "502 should map to UnexpectedStatusCode(502), got {:?}",
+        err
+    );
+}
+
 #[tokio::test]
 async fn status_429_maps_to_rate_limited_without_retry_after() {
     let err = call_with_status(429, "slow down")

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -235,13 +235,100 @@ async fn status_500_maps_to_internal_server_error() {
 }
 
 #[tokio::test]
-async fn status_404_maps_to_unexpected_status_code() {
+async fn status_403_maps_to_forbidden() {
+    let err = call_with_status(403, "nope")
+        .await
+        .expect_err("403 should be Err");
+    assert!(
+        matches!(err, Error::Forbidden),
+        "403 should map to Forbidden, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn status_404_maps_to_not_found() {
     let err = call_with_status(404, "nope")
         .await
         .expect_err("404 should be Err");
     assert!(
-        matches!(err, Error::UnexpectedStatusCode(404)),
-        "404 should map to UnexpectedStatusCode(404), got {:?}",
+        matches!(err, Error::NotFound),
+        "404 should map to NotFound, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn status_429_maps_to_rate_limited_without_retry_after() {
+    let err = call_with_status(429, "slow down")
+        .await
+        .expect_err("429 should be Err");
+    assert!(
+        matches!(
+            err,
+            Error::RateLimited {
+                retry_after: None
+            }
+        ),
+        "429 without Retry-After should map to RateLimited {{ retry_after: None }}, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn status_429_surfaces_retry_after_seconds() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/api/v1/liquidation/heatmap")
+        .with_status(429)
+        .with_header("Retry-After", "42")
+        .with_body("slow down")
+        .create_async()
+        .await;
+
+    let liq = mock_client(server.url()).liquidation();
+    let err = liq
+        .heatmap(LiquidationHeatmapOptions::new())
+        .await
+        .expect_err("429 should be Err");
+    assert!(
+        matches!(
+            err,
+            Error::RateLimited {
+                retry_after: Some(d)
+            } if d == std::time::Duration::from_secs(42)
+        ),
+        "429 with Retry-After: 42 should surface Duration::from_secs(42), got {:?}",
+        err
+    );
+}
+
+/// A `Retry-After` HTTP-date (rather than delay-seconds) is not parsed and must
+/// yield `None` without panicking, while still mapping to `RateLimited`.
+#[tokio::test]
+async fn status_429_http_date_retry_after_yields_none() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/api/v1/liquidation/heatmap")
+        .with_status(429)
+        .with_header("Retry-After", "Wed, 21 Oct 2015 07:28:00 GMT")
+        .with_body("slow down")
+        .create_async()
+        .await;
+
+    let liq = mock_client(server.url()).liquidation();
+    let err = liq
+        .heatmap(LiquidationHeatmapOptions::new())
+        .await
+        .expect_err("429 should be Err");
+    assert!(
+        matches!(
+            err,
+            Error::RateLimited {
+                retry_after: None
+            }
+        ),
+        "429 with HTTP-date Retry-After should map to RateLimited {{ retry_after: None }}, got {:?}",
         err
     );
 }
@@ -499,4 +586,73 @@ fn blocking_liquidation_heatmap_smoke() {
 
     mock.assert();
     assert!(res.is_ok(), "expected Ok, got {:?}", res);
+}
+
+/// Blocking mirror maps 403/404/429 to the same dedicated variants as async,
+/// including surfacing `Retry-After` on 429.
+#[cfg(feature = "blocking")]
+fn blocking_call_with_status(
+    status: usize,
+    retry_after: Option<&str>,
+) -> datamaxi::api::Result<LiquidationHeatmapResponse> {
+    let mut server = mockito::Server::new();
+    let mut m = server
+        .mock("GET", "/api/v1/liquidation/heatmap")
+        .with_status(status)
+        .with_body("body");
+    if let Some(ra) = retry_after {
+        m = m.with_header("Retry-After", ra);
+    }
+    let _mock = m.create();
+
+    let liq = mock_blocking_client(server.url()).liquidation();
+    liq.heatmap(LiquidationHeatmapOptions::new())
+}
+
+#[cfg(feature = "blocking")]
+#[test]
+fn blocking_status_403_maps_to_forbidden() {
+    let err = blocking_call_with_status(403, None).expect_err("403 should be Err");
+    assert!(
+        matches!(err, Error::Forbidden),
+        "403 should map to Forbidden, got {:?}",
+        err
+    );
+}
+
+#[cfg(feature = "blocking")]
+#[test]
+fn blocking_status_404_maps_to_not_found() {
+    let err = blocking_call_with_status(404, None).expect_err("404 should be Err");
+    assert!(
+        matches!(err, Error::NotFound),
+        "404 should map to NotFound, got {:?}",
+        err
+    );
+}
+
+#[cfg(feature = "blocking")]
+#[test]
+fn blocking_status_429_maps_to_rate_limited_without_retry_after() {
+    let err = blocking_call_with_status(429, None).expect_err("429 should be Err");
+    assert!(
+        matches!(err, Error::RateLimited { retry_after: None }),
+        "429 without Retry-After should map to RateLimited {{ retry_after: None }}, got {:?}",
+        err
+    );
+}
+
+#[cfg(feature = "blocking")]
+#[test]
+fn blocking_status_429_surfaces_retry_after_seconds() {
+    let err = blocking_call_with_status(429, Some("42")).expect_err("429 should be Err");
+    assert!(
+        matches!(
+            err,
+            Error::RateLimited { retry_after: Some(d) }
+            if d == std::time::Duration::from_secs(42)
+        ),
+        "429 with Retry-After: 42 should surface Duration::from_secs(42), got {:?}",
+        err
+    );
 }


### PR DESCRIPTION
## Summary

`handle_response` (async + blocking) previously collapsed everything except 200/400/401/500 into `Error::UnexpectedStatusCode`. This adds dedicated variants so callers can detect throttling and missing/forbidden resources.

- 429 -> `Error::RateLimited { retry_after: Option<Duration> }`, parsing the `Retry-After` header (delay-seconds form; HTTP-date form yields `None`, no panic).
- 403 -> `Error::Forbidden`.
- 404 -> `Error::NotFound`.
- `UnexpectedStatusCode` remains the catch-all; body-truncation preserved for message-carrying variants. `Error` stays `#[non_exhaustive]`.

Mapped identically in both the async and blocking `handle_response`.

## Test plan
- Extended `tests/wire_contract.rs`: async 403/404/429 (no header), 429 with `Retry-After: 42` asserting `Duration::from_secs(42)`, and 429 with an HTTP-date header asserting `None`.
- Blocking mirror (under `blocking` feature): 403/404/429 + 429 with `Retry-After: 42`.
- `cargo build`, `cargo test --all-features` (25 pass), `cargo clippy --all-features --all-targets -- -D warnings` all clean.

Note: issue #66 (retry/backoff) also touches api.rs in a sibling worktree; merge reconciliation expected.

Closes #63