### PR TITLE
ci: declare MSRV 1.86 + add MSRV CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,3 +38,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-targets
+
+  msrv:
+    name: msrv
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.86.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --all-features
+      - run: cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "datamaxi"
 version = "0.12.0"
 edition = "2021"
+rust-version = "1.86"
 readme = "README.md"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ wrappers under `datamaxi::blocking`:
 datamaxi = { git = "https://github.com/bisonai/datamaxi-rust.git", features = ["blocking"] }
 ```
 
+### Minimum Supported Rust Version (MSRV)
+
+This crate requires **Rust 1.86** or newer. The MSRV is verified in CI and
+may be raised in a minor version bump.
+
 ## Configuration
 
 Private API endpoints require an API key. Register at [datamaxiplus.com/auth](https://datamaxiplus.com/auth) to get one.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,11 @@
 //! datamaxi = { git = "https://github.com/bisonai/datamaxi-rust.git" }
 //! ```
 //!
+//! ### Minimum Supported Rust Version (MSRV)
+//!
+//! This crate requires **Rust 1.86** or newer. The MSRV is verified in CI and
+//! may be raised in a minor version bump.
+//!
 //! ## Configuration
 //!
 //! Private API endpoints are protected by an API key.


### PR DESCRIPTION
Declares the crate's MSRV and enforces it in CI (issue #65).

## Changes
- `rust-version = "1.86"` in `Cargo.toml` `[package]`.
- New `msrv` job in `rust.yml`: pins `dtolnay/rust-toolchain@1.86.0` and runs `cargo build --all-features` + `cargo test --all-features` (blocking covered).
- MSRV documented in the `src/lib.rs` `//!` doc comment; README updated by hand to match (the committed README has drifted from lib.rs, so a full `cargo readme` regen was intentionally avoided to keep the diff in-scope).

## Chosen MSRV: 1.86
Cargo.lock is gitignored, so CI resolves latest-compatible deps; the effective floor is set by the newest transitive dep. Current tree pulls `icu` 2.2 (via reqwest 0.12 -> url -> idna), which requires rustc 1.86.

## Verification
Installed toolchains via rustup, no committed lock:
- `cargo +1.85.0 build --all-features` -> fails: `icu_properties_data@2.2.0 requires rustc 1.86`.
- `cargo +1.86.0 build --all-features` -> OK; `cargo +1.86.0 test --all-features` -> all 17 wire/unit tests + doc-tests pass.
- Stable: build, test, clippy (`-D warnings`), fmt all pass.

Note: because the lockfile is not committed, MSRV floats with the newest dep and may need bumping over time; the `rust-version` field enables Cargo's MSRV-aware resolver on newer toolchains to help keep it stable.

Closes #65