### PR TITLE
Cap async error-body read in handle_response

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -237,13 +237,28 @@ impl Client {
     }
 }
 
+/// Reads at most ~1000 bytes of an async response body, streaming chunk by
+/// chunk rather than buffering the whole body. Mirrors the blocking path's
+/// `response.take(1000).read_to_string(&mut body)`. Invalid UTF-8 in the
+/// truncated bytes is replaced lossily.
+async fn read_body_capped(mut response: reqwest::Response) -> String {
+    let mut buf: Vec<u8> = Vec::new();
+    while buf.len() < 1000 {
+        match response.chunk().await {
+            Ok(Some(chunk)) => buf.extend_from_slice(&chunk),
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
+    truncate_body(String::from_utf8_lossy(&buf).into_owned())
+}
+
 /// Processes an async response from the API and returns the result.
 async fn handle_response<T: DeserializeOwned>(response: reqwest::Response) -> Result<T> {
     match response.status() {
         StatusCode::OK => Ok(response.json::<T>().await?),
         StatusCode::INTERNAL_SERVER_ERROR => {
-            let body = response.text().await.unwrap_or_default();
-            Err(Error::InternalServerError(truncate_body(body)))
+            Err(Error::InternalServerError(read_body_capped(response).await))
         }
         StatusCode::UNAUTHORIZED => Err(Error::Unauthorized),
         StatusCode::FORBIDDEN => Err(Error::Forbidden),
@@ -251,10 +266,7 @@ async fn handle_response<T: DeserializeOwned>(response: reqwest::Response) -> Re
         StatusCode::TOO_MANY_REQUESTS => Err(Error::RateLimited {
             retry_after: parse_retry_after(response.headers()),
         }),
-        StatusCode::BAD_REQUEST => {
-            let body = response.text().await.unwrap_or_default();
-            Err(Error::BadRequest(truncate_body(body)))
-        }
+        StatusCode::BAD_REQUEST => Err(Error::BadRequest(read_body_capped(response).await)),
         status => Err(Error::UnexpectedStatusCode(status.as_u16())),
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -245,7 +245,13 @@ async fn read_body_capped(mut response: reqwest::Response) -> String {
     let mut buf: Vec<u8> = Vec::new();
     while buf.len() < 1000 {
         match response.chunk().await {
-            Ok(Some(chunk)) => buf.extend_from_slice(&chunk),
+            Ok(Some(chunk)) => {
+                // Take only up to the remaining budget so a single oversized
+                // chunk can't push `buf` past the cap — a byte-exact bound
+                // matching the blocking path's `response.take(1000)`.
+                let take = (1000 - buf.len()).min(chunk.len());
+                buf.extend_from_slice(&chunk[..take]);
+            }
             Ok(None) => break,
             Err(_) => break,
         }

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -235,6 +235,48 @@ async fn status_500_maps_to_internal_server_error() {
     );
 }
 
+/// A `400` body over 1000 bytes is truncated on the wire, mirroring the
+/// blocking path's `response.take(1000)`. Guards against the async path
+/// buffering the full body before truncating (issue #74).
+#[tokio::test]
+async fn status_400_body_over_1000_bytes_is_truncated() {
+    let big_body = "a".repeat(2000);
+    let err = call_with_status(400, &big_body)
+        .await
+        .expect_err("400 should be Err");
+    match err {
+        Error::BadRequest(body) => {
+            assert!(
+                body.len() <= 1000,
+                "expected truncated body <= 1000 bytes, got {}",
+                body.len()
+            );
+        }
+        other => panic!("expected BadRequest, got {:?}", other),
+    }
+}
+
+/// A `500` body over 1000 bytes is truncated on the wire (async parity with
+/// the blocking path). Guards against the async path buffering the full body
+/// before truncating (issue #74).
+#[tokio::test]
+async fn status_500_body_over_1000_bytes_is_truncated() {
+    let big_body = "b".repeat(2000);
+    let err = call_with_status(500, &big_body)
+        .await
+        .expect_err("500 should be Err");
+    match err {
+        Error::InternalServerError(body) => {
+            assert!(
+                body.len() <= 1000,
+                "expected truncated body <= 1000 bytes, got {}",
+                body.len()
+            );
+        }
+        other => panic!("expected InternalServerError, got {:?}", other),
+    }
+}
+
 #[tokio::test]
 async fn status_403_maps_to_forbidden() {
     let err = call_with_status(403, "nope")


### PR DESCRIPTION
## Summary
- Async `handle_response` (`src/api.rs`) buffered the entire 400/500 error body via `response.text().await` before truncating to 1000 bytes, unlike the blocking path's `response.take(1000).read_to_string(...)`.
- Added `read_body_capped`: streams the async body via `response.chunk().await` in a loop, stopping once >=1000 bytes accumulated, then reuses `truncate_body` for the final char-boundary cut. Applied to both `INTERNAL_SERVER_ERROR` and `BAD_REQUEST` arms.
- Blocking path untouched.

## Test plan
- Added `status_400_body_over_1000_bytes_is_truncated` and `status_500_body_over_1000_bytes_is_truncated` in `tests/wire_contract.rs` (2000-byte mock body, assert returned `Error::BadRequest`/`InternalServerError` string is <=1000 bytes).
- `cargo build` - ok
- `cargo test` - 6 unit + 25 live + 33 wire_contract + 2 doc, all pass
- `cargo test --features blocking` - 41 wire_contract (incl. new tests) + others, all pass
- `cargo clippy --all-targets --all-features -- -D warnings` - clean
- `cargo fmt --check` - clean

Closes #74