### PR TITLE
feat: add pagination helpers for paged endpoints (#88)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,7 @@
 use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
 use std::collections::BTreeMap;
+use std::marker::PhantomData;
 use std::time::Duration;
 use thiserror::Error;
 
@@ -346,6 +347,212 @@ impl Client {
             await
         )
     }
+
+    /// Returns an auto-paginator over a paged endpoint (see [`Paginated`]).
+    ///
+    /// `params` seeds the query string for every page (e.g. `limit`, `sort`,
+    /// filters); a `page` key in `params` sets the starting page (defaults to
+    /// `1`) and is overwritten on each subsequent request as the paginator
+    /// advances. Call [`Paginator::next_page`] in a loop to walk forward.
+    pub fn paginate<T>(
+        &self,
+        endpoint: impl Into<String>,
+        params: BTreeMap<String, String>,
+    ) -> Paginator<T>
+    where
+        T: Paginated + DeserializeOwned,
+    {
+        Paginator::new(self.clone(), endpoint, params)
+    }
+}
+
+/// Implemented by paged response envelopes — the `page`/`limit`/`total`/`data`
+/// shape shared by several Datamaxi+ endpoints (e.g. `CexAnnouncementsResponse`) —
+/// so [`Client::paginate`] / [`blocking::Client::paginate`] can drive a generic
+/// auto-paginator over them without codegen needing to emit a bespoke helper
+/// per endpoint.
+///
+/// Only response envelopes that report all three of `page`, `limit`, and
+/// `total` implement this trait today; a handful of generated responses carry
+/// `page`/`limit`/`data` without a `total` (e.g. `FundingRateHistoryResponse`)
+/// and are not yet covered — see the crate's pagination docs.
+pub trait Paginated {
+    /// The item type yielded per page (the envelope's `data` element type).
+    type Item;
+
+    /// The 1-based page number this response represents.
+    fn page(&self) -> i64;
+
+    /// The page size requested/echoed back by the server.
+    fn limit(&self) -> i64;
+
+    /// The total number of items across all pages, if the envelope reports one.
+    fn total(&self) -> Option<i64>;
+
+    /// Consumes the response, yielding this page's items.
+    fn into_items(self) -> Vec<Self::Item>;
+}
+
+/// Implements [`Paginated`] for a `page`/`limit`/`total`/`data` response
+/// envelope, mapping its fields directly (`data` -> items).
+macro_rules! impl_paginated {
+    ($response:ty, $item:ty) => {
+        impl Paginated for $response {
+            type Item = $item;
+
+            fn page(&self) -> i64 {
+                self.page
+            }
+
+            fn limit(&self) -> i64 {
+                self.limit
+            }
+
+            fn total(&self) -> Option<i64> {
+                Some(self.total)
+            }
+
+            fn into_items(self) -> Vec<Self::Item> {
+                self.data
+            }
+        }
+    };
+}
+
+impl_paginated!(
+    crate::generated::CexAnnouncementsResponse,
+    crate::generated::CexAnnouncementsView
+);
+impl_paginated!(
+    crate::generated::CexTokenUpdatesResponse,
+    crate::generated::CexTokenUpdatesView
+);
+impl_paginated!(
+    crate::generated::OpenInterestOverviewResponse,
+    crate::generated::OpenInterestOverviewView
+);
+impl_paginated!(
+    crate::generated::PremiumResponse,
+    crate::generated::PremiumView
+);
+impl_paginated!(
+    crate::generated::TelegramChannelsResponse,
+    crate::generated::TelegramChannelsView
+);
+impl_paginated!(
+    crate::generated::TelegramMessagesResponse,
+    crate::generated::TelegramMessagesView
+);
+
+/// Async auto-paginator returned by [`Client::paginate`].
+///
+/// Not a [`futures::Stream`](https://docs.rs/futures) — the crate takes no
+/// dependency on `futures` for this — `next_page` is a plain cursor:
+///
+/// ```no_run
+/// use datamaxi::api::ClientBuilder;
+/// use datamaxi::CexAnnouncementsResponse;
+/// use std::collections::BTreeMap;
+///
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = ClientBuilder::new().api_key("my_api_key").build()?;
+/// let mut pages = client
+///     .paginate::<CexAnnouncementsResponse>("/api/v1/cex/announcements", BTreeMap::new());
+///
+/// while let Some(items) = pages.next_page().await? {
+///     for item in items {
+///         println!("{}", item.title);
+///     }
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub struct Paginator<T: Paginated> {
+    client: Client,
+    endpoint: String,
+    params: BTreeMap<String, String>,
+    next_page: i64,
+    done: bool,
+    _marker: PhantomData<T>,
+}
+
+impl<T> Paginator<T>
+where
+    T: Paginated + DeserializeOwned,
+{
+    fn new(client: Client, endpoint: impl Into<String>, params: BTreeMap<String, String>) -> Self {
+        let next_page = starting_page(&params);
+        Paginator {
+            client,
+            endpoint: endpoint.into(),
+            params,
+            next_page,
+            done: false,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Fetches and returns the next page's items, or `Ok(None)` once the
+    /// server has no more data: an empty page, or (when the envelope reports
+    /// a `total`) a page reaching `page * limit >= total`. Once exhausted,
+    /// further calls keep returning `Ok(None)` rather than re-fetching.
+    pub async fn next_page(&mut self) -> Result<Option<Vec<T::Item>>> {
+        if self.done {
+            return Ok(None);
+        }
+
+        let mut params = self.params.clone();
+        params.insert("page".to_string(), self.next_page.to_string());
+
+        let response: T = self.client.get(&self.endpoint, Some(params)).await?;
+        Ok(self.consume_response(response))
+    }
+
+    /// Shared bookkeeping for a fetched page: advances `next_page`, marks
+    /// [`Paginator::done`] on an empty page or on reaching `total`, and
+    /// extracts the items. Kept free of `async`/blocking specifics so both
+    /// flavors share the exact same terminal-condition logic.
+    fn consume_response(&mut self, response: T) -> Option<Vec<T::Item>> {
+        consume_page(&mut self.next_page, &mut self.done, response)
+    }
+}
+
+/// The starting page for a paginator: the caller-supplied `page` param when
+/// present and positive, otherwise `1`.
+fn starting_page(params: &BTreeMap<String, String>) -> i64 {
+    params
+        .get("page")
+        .and_then(|p| p.parse::<i64>().ok())
+        .filter(|&p| p > 0)
+        .unwrap_or(1)
+}
+
+/// Shared terminal-condition logic for both the async and blocking
+/// paginators: given a fetched `response`, updates `next_page`/`done` and
+/// returns `Some(items)`, or `None` once there is nothing left to yield.
+fn consume_page<T: Paginated>(
+    next_page: &mut i64,
+    done: &mut bool,
+    response: T,
+) -> Option<Vec<T::Item>> {
+    let page = response.page();
+    let limit = response.limit();
+    let total = response.total();
+    let items = response.into_items();
+
+    if items.is_empty() {
+        *done = true;
+        return None;
+    }
+
+    *next_page = page + 1;
+    if let Some(total) = total {
+        if limit > 0 && page.saturating_mul(limit) >= total {
+            *done = true;
+        }
+    }
+
+    Some(items)
 }
 
 /// Reads at most [`MAX_ERROR_BODY_BYTES`] of an async response body, streaming
@@ -542,15 +749,16 @@ pub enum Error {
 #[cfg(feature = "blocking")]
 pub mod blocking {
     use super::{
-        backoff_delay, is_retryable_error, is_retryable_status, map_error_status,
-        retry_delay_for_response, truncate_body, user_agent, BuilderState, Error, Result,
-        RetryConfig, BASE_URL, DEFAULT_TIMEOUT, MAX_ERROR_BODY_BYTES,
+        backoff_delay, consume_page, is_retryable_error, is_retryable_status, map_error_status,
+        retry_delay_for_response, starting_page, truncate_body, user_agent, BuilderState, Error,
+        Paginated, Result, RetryConfig, BASE_URL, DEFAULT_TIMEOUT, MAX_ERROR_BODY_BYTES,
     };
     use reqwest::blocking::Response;
     use reqwest::StatusCode;
     use serde::de::DeserializeOwned;
     use std::collections::BTreeMap;
     use std::io::Read;
+    use std::marker::PhantomData;
     use std::time::Duration;
 
     /// Build the underlying blocking HTTP client with our defaults. Falls back
@@ -616,6 +824,99 @@ pub mod blocking {
                 handle_response,
                 std::thread::sleep
             )
+        }
+
+        /// Returns an auto-paginator over a paged endpoint (see
+        /// [`super::Paginated`]). Mirrors the async [`super::Client::paginate`];
+        /// see its docs for how `params` and the starting page work.
+        pub fn paginate<T>(
+            &self,
+            endpoint: impl Into<String>,
+            params: BTreeMap<String, String>,
+        ) -> Paginator<T>
+        where
+            T: Paginated + DeserializeOwned,
+        {
+            Paginator::new(self.clone(), endpoint, params)
+        }
+    }
+
+    /// Blocking auto-paginator returned by [`Client::paginate`], implementing
+    /// [`Iterator`] over pages of items (one `Result<Vec<T::Item>>` per page).
+    /// Iteration stops (yields `None`) once the server reports no more data,
+    /// and after the first `Err`, so a caller can `?`-propagate mid-loop
+    /// without risking a retry of the same failing page.
+    ///
+    /// ```no_run
+    /// use datamaxi::api::blocking::ClientBuilder;
+    /// use datamaxi::CexAnnouncementsResponse;
+    /// use std::collections::BTreeMap;
+    ///
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = ClientBuilder::new().api_key("my_api_key").build()?;
+    /// for page in
+    ///     client.paginate::<CexAnnouncementsResponse>("/api/v1/cex/announcements", BTreeMap::new())
+    /// {
+    ///     for item in page? {
+    ///         println!("{}", item.title);
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub struct Paginator<T: Paginated> {
+        client: Client,
+        endpoint: String,
+        params: BTreeMap<String, String>,
+        next_page: i64,
+        done: bool,
+        _marker: PhantomData<T>,
+    }
+
+    impl<T> Paginator<T>
+    where
+        T: Paginated + DeserializeOwned,
+    {
+        fn new(
+            client: Client,
+            endpoint: impl Into<String>,
+            params: BTreeMap<String, String>,
+        ) -> Self {
+            let next_page = starting_page(&params);
+            Paginator {
+                client,
+                endpoint: endpoint.into(),
+                params,
+                next_page,
+                done: false,
+                _marker: PhantomData,
+            }
+        }
+    }
+
+    impl<T> Iterator for Paginator<T>
+    where
+        T: Paginated + DeserializeOwned,
+    {
+        type Item = Result<Vec<T::Item>>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.done {
+                return None;
+            }
+
+            let mut params = self.params.clone();
+            params.insert("page".to_string(), self.next_page.to_string());
+
+            match self.client.get::<T>(&self.endpoint, Some(params)) {
+                Ok(response) => consume_page(&mut self.next_page, &mut self.done, response).map(Ok),
+                Err(error) => {
+                    // Stop iterating after an error rather than retrying the
+                    // same page forever.
+                    self.done = true;
+                    Some(Err(error))
+                }
+            }
         }
     }
 
@@ -815,6 +1116,135 @@ mod tests {
         assert_eq!(
             retry_delay_for_response(&config, StatusCode::TOO_MANY_REQUESTS, &headers, 0),
             RETRY_MAX_DELAY
+        );
+    }
+
+    // --- Pagination (issue #88) --------------------------------------------
+
+    /// A minimal `page`/`limit`/`total`/`data` envelope for exercising
+    /// [`consume_page`] / [`starting_page`] without a real generated response
+    /// type.
+    #[derive(Debug)]
+    struct DummyPage {
+        page: i64,
+        limit: i64,
+        total: Option<i64>,
+        data: Vec<i32>,
+    }
+
+    impl Paginated for DummyPage {
+        type Item = i32;
+
+        fn page(&self) -> i64 {
+            self.page
+        }
+
+        fn limit(&self) -> i64 {
+            self.limit
+        }
+
+        fn total(&self) -> Option<i64> {
+            self.total
+        }
+
+        fn into_items(self) -> Vec<i32> {
+            self.data
+        }
+    }
+
+    #[test]
+    fn starting_page_defaults_to_one_when_absent_or_invalid() {
+        assert_eq!(starting_page(&BTreeMap::new()), 1);
+
+        let mut params = BTreeMap::new();
+        params.insert("page".to_string(), "not-a-number".to_string());
+        assert_eq!(starting_page(&params), 1);
+
+        params.insert("page".to_string(), "0".to_string());
+        assert_eq!(starting_page(&params), 1);
+
+        params.insert("page".to_string(), "-1".to_string());
+        assert_eq!(starting_page(&params), 1);
+    }
+
+    #[test]
+    fn starting_page_honors_explicit_positive_page() {
+        let mut params = BTreeMap::new();
+        params.insert("page".to_string(), "5".to_string());
+        assert_eq!(starting_page(&params), 5);
+    }
+
+    #[test]
+    fn consume_page_continues_while_below_total() {
+        let mut next_page = 1;
+        let mut done = false;
+        let page = DummyPage {
+            page: 1,
+            limit: 2,
+            total: Some(5),
+            data: vec![1, 2],
+        };
+
+        let items = consume_page(&mut next_page, &mut done, page);
+
+        assert_eq!(items, Some(vec![1, 2]));
+        assert_eq!(next_page, 2);
+        assert!(!done);
+    }
+
+    #[test]
+    fn consume_page_terminates_when_total_reached() {
+        let mut next_page = 2;
+        let mut done = false;
+        // page * limit == 4 >= total (3): last page.
+        let page = DummyPage {
+            page: 2,
+            limit: 2,
+            total: Some(3),
+            data: vec![3],
+        };
+
+        let items = consume_page(&mut next_page, &mut done, page);
+
+        assert_eq!(items, Some(vec![3]));
+        assert!(done, "reaching total must mark the paginator done");
+    }
+
+    #[test]
+    fn consume_page_terminates_on_empty_data_regardless_of_total() {
+        let mut next_page = 2;
+        let mut done = false;
+        // total (100) not yet reached, but an empty page still terminates.
+        let page = DummyPage {
+            page: 2,
+            limit: 1,
+            total: Some(100),
+            data: Vec::<i32>::new(),
+        };
+
+        let items = consume_page(&mut next_page, &mut done, page);
+
+        assert_eq!(items, None);
+        assert!(done);
+    }
+
+    #[test]
+    fn consume_page_without_total_relies_on_empty_page() {
+        let mut next_page = 1;
+        let mut done = false;
+        let page = DummyPage {
+            page: 1,
+            limit: 10,
+            total: None,
+            data: vec![1],
+        };
+
+        let items = consume_page(&mut next_page, &mut done, page);
+
+        assert_eq!(items, Some(vec![1]));
+        assert!(
+            !done,
+            "without a reported total, only an empty page should terminate"
         );
     }
 }

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -1,0 +1,211 @@
+//! Integration tests for the auto-paginator added for issue #88
+//! ([`datamaxi::api::Client::paginate`] / [`datamaxi::api::blocking::Client::paginate`]).
+//!
+//! These drive a real `page`/`limit`/`total`/`data` envelope
+//! (`CexAnnouncementsResponse`) through a mock server and lock: multi-page
+//! traversal, the `page * limit >= total` terminal condition, the empty-page
+//! terminal condition, and honoring a caller-supplied starting page.
+
+use datamaxi::api::{Client, ClientBuilder};
+use datamaxi::CexAnnouncementsResponse;
+use mockito::Matcher;
+use std::collections::BTreeMap;
+
+const API_KEY: &str = "test-api-key";
+
+fn mock_client(base_url: String) -> Client {
+    ClientBuilder::new()
+        .api_key(API_KEY)
+        .base_url(base_url)
+        .build()
+        .expect("mock client builds")
+}
+
+/// A page body for `CexAnnouncementsResponse`: `n` announcements, plus the
+/// envelope's `page`/`limit`/`total`.
+fn page_body(page: i64, limit: i64, total: i64, n: usize) -> String {
+    let data: Vec<String> = (0..n)
+        .map(|i| {
+            format!(
+                r#"{{"c":"listing","d":0,"e":"binance","s":"summary","t":"item-{page}-{i}","u":"https://example.com"}}"#
+            )
+        })
+        .collect();
+    format!(
+        r#"{{"data":[{}],"limit":{limit},"page":{page},"total":{total}}}"#,
+        data.join(",")
+    )
+}
+
+/// Two pages of two items each, `total: 3` reached exactly on the second
+/// page (`page * limit >= total`): the paginator fetches both pages, then
+/// stops without a third HTTP call.
+#[tokio::test]
+async fn paginate_walks_multiple_pages_until_total_reached() {
+    let mut server = mockito::Server::new_async().await;
+
+    let page1 = server
+        .mock("GET", "/api/v1/cex/announcements")
+        .match_header("X-DTMX-APIKEY", API_KEY)
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("limit".into(), "2".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(page_body(1, 2, 3, 2))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let page2 = server
+        .mock("GET", "/api/v1/cex/announcements")
+        .match_header("X-DTMX-APIKEY", API_KEY)
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "2".into()),
+            Matcher::UrlEncoded("limit".into(), "2".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(page_body(2, 2, 3, 1))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let client = mock_client(server.url());
+    let mut params = BTreeMap::new();
+    params.insert("limit".to_string(), "2".to_string());
+    let mut pages =
+        client.paginate::<CexAnnouncementsResponse>("/api/v1/cex/announcements", params);
+
+    let first = pages.next_page().await.expect("first page ok");
+    assert_eq!(first.map(|items| items.len()), Some(2));
+
+    let second = pages.next_page().await.expect("second page ok");
+    assert_eq!(second.map(|items| items.len()), Some(1));
+
+    // Terminal: no third HTTP call should be made.
+    let third = pages.next_page().await.expect("terminal call ok");
+    assert!(third.is_none());
+
+    page1.assert_async().await;
+    page2.assert_async().await;
+}
+
+/// A page whose `data` comes back empty terminates the paginator even though
+/// `total` hasn't been reached yet (e.g. a stale/over-reported `total`).
+#[tokio::test]
+async fn paginate_stops_on_empty_page_regardless_of_total() {
+    let mut server = mockito::Server::new_async().await;
+
+    let page1 = server
+        .mock("GET", "/api/v1/cex/announcements")
+        .match_query(Matcher::UrlEncoded("page".into(), "1".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(page_body(1, 1, 100, 1))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let page2 = server
+        .mock("GET", "/api/v1/cex/announcements")
+        .match_query(Matcher::UrlEncoded("page".into(), "2".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(page_body(2, 1, 100, 0))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let client = mock_client(server.url());
+    let mut pages =
+        client.paginate::<CexAnnouncementsResponse>("/api/v1/cex/announcements", BTreeMap::new());
+
+    let first = pages.next_page().await.expect("first page ok");
+    assert_eq!(first.map(|items| items.len()), Some(1));
+
+    let second = pages.next_page().await.expect("empty page ok");
+    assert!(second.is_none());
+
+    page1.assert_async().await;
+    page2.assert_async().await;
+}
+
+/// A `page` key in the seed params sets the starting page, rather than
+/// always starting at `1`.
+#[tokio::test]
+async fn paginate_honors_starting_page_param() {
+    let mut server = mockito::Server::new_async().await;
+
+    let mock = server
+        .mock("GET", "/api/v1/cex/announcements")
+        .match_query(Matcher::UrlEncoded("page".into(), "3".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(page_body(3, 1, 3, 0))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let client = mock_client(server.url());
+    let mut params = BTreeMap::new();
+    params.insert("page".to_string(), "3".to_string());
+    let mut pages =
+        client.paginate::<CexAnnouncementsResponse>("/api/v1/cex/announcements", params);
+
+    let first = pages.next_page().await.expect("first page ok");
+    assert!(first.is_none(), "empty page 3 should terminate immediately");
+
+    mock.assert_async().await;
+}
+
+/// The blocking mirror ([`datamaxi::api::blocking::Client::paginate`])
+/// implements [`Iterator`], yielding one `Result<Vec<_>>` per page and
+/// stopping once `page * limit >= total`.
+#[cfg(feature = "blocking")]
+#[test]
+fn blocking_paginate_walks_multiple_pages_until_total_reached() {
+    let mut server = mockito::Server::new();
+
+    let page1 = server
+        .mock("GET", "/api/v1/cex/announcements")
+        .match_query(Matcher::AllOf(vec![Matcher::UrlEncoded(
+            "page".into(),
+            "1".into(),
+        )]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(page_body(1, 2, 3, 2))
+        .expect(1)
+        .create();
+
+    let page2 = server
+        .mock("GET", "/api/v1/cex/announcements")
+        .match_query(Matcher::AllOf(vec![Matcher::UrlEncoded(
+            "page".into(),
+            "2".into(),
+        )]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(page_body(2, 2, 3, 1))
+        .expect(1)
+        .create();
+
+    let client = datamaxi::api::blocking::ClientBuilder::new()
+        .api_key(API_KEY)
+        .base_url(server.url())
+        .build()
+        .expect("mock blocking client builds");
+
+    let pages: Vec<_> = client
+        .paginate::<CexAnnouncementsResponse>("/api/v1/cex/announcements", BTreeMap::new())
+        .collect();
+
+    assert_eq!(pages.len(), 2, "expected exactly two pages, got {pages:?}");
+    assert_eq!(pages[0].as_ref().unwrap().len(), 2);
+    assert_eq!(pages[1].as_ref().unwrap().len(), 1);
+
+    page1.assert();
+    page2.assert();
+}


### PR DESCRIPTION
Closes #88

## Design chosen
Generic auto-paginator at the transport layer (`src/api.rs`), not codegen — `generated.rs` is untouched.

- New `Paginated` trait (`page`/`limit`/`total`/`into_items`) implemented for the 6 generated response types that report a full `page`/`limit`/`total`/`data` envelope: `CexAnnouncementsResponse`, `CexTokenUpdatesResponse`, `OpenInterestOverviewResponse`, `PremiumResponse`, `TelegramChannelsResponse`, `TelegramMessagesResponse`. Trait impls live in `api.rs` (implementing a local trait for a generated type is allowed without touching `generated.rs`).
- Async: `Client::paginate::<T>(endpoint, params) -> Paginator<T>`, driven via `Paginator::next_page() -> Result<Option<Vec<T::Item>>>` — a plain cursor, not a `futures::Stream`, so no new dependency is added.
- Blocking (`blocking` feature): `blocking::Client::paginate::<T>(...) -> blocking::Paginator<T>` implementing `Iterator<Item = Result<Vec<T::Item>>>`, one page per `next()`.
- Terminal condition: an empty `data` page, or (when `total` is reported) `page * limit >= total`. A `page` key in the seed `params` sets the starting page (default `1`).

## Tests added
- `tests/pagination.rs`: multi-page traversal to the `total`-reached terminal condition, empty-page termination independent of `total`, honoring a caller-supplied starting page, and the blocking `Iterator` mirror.
- `src/api.rs` unit tests for the shared `starting_page`/`consume_page` helpers (defaults, explicit starting page, continue/terminate/no-total cases).

## Scope limitations
- Only covers response envelopes reporting all of `page`/`limit`/`total`/`data`. A few generated responses have `page`/`limit`/`data` but no `total` (e.g. `FundingRateHistoryResponse`) — not wired up; documented on the `Paginated` trait. Codegen emitting `Paginated` automatically per spec is left for a follow-up, per the issue's own suggested phasing.
- No per-endpoint-group convenience wrapper (e.g. `client.cex_announcements().paginate(...)`) — callers use `Client::paginate` directly with the endpoint path and params, matching the issue's suggested "generic paginate(endpoint, params) helper" starting point.

## Verification
- `cargo build` / `cargo build --all-features`: pass
- `cargo test` / `cargo test --all-features`: pass (one pre-existing, unrelated flake in `tests/live.rs::live_liquidation_symbol_history` hitting the real API under `cargo test`'s default multi-threading — not touched by this change; CI runs live tests with `--test-threads=1` per existing convention)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean