### PR TITLE
feat: opt-in tracing spans + custom http_client hook (#89)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,19 @@ thiserror = "2.0.11"
 # surface already requires a Tokio runtime, so this adds no new runtime
 # requirement — it only makes the timer dependency explicit.
 tokio = { version = "1", default-features = false, features = ["time"] }
+# Optional: request-level spans/events in `get_loop!`, behind the `tracing`
+# feature. Compiles away entirely (no dependency pulled in) when disabled.
+tracing = { version = "0.1", optional = true }
 
 [features]
 default = []
 blocking = ["reqwest/blocking"]
+tracing = ["dep:tracing"]
 
 [dev-dependencies]
 dotenvy = "0.15.7"
 mockito = "1.5.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+# Unconditional dev-dependency so tests can assert on emitted spans/events
+# when built with `--features tracing`; does not affect release builds.
+tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ wrappers under `datamaxi::blocking`:
 datamaxi = { git = "https://github.com/bisonai/datamaxi-rust.git", features = ["blocking"] }
 ```
 
+### Observability
+
+Two independent, opt-in hooks:
+
+- **`tracing` feature** — instruments each request with a span (`method`,
+  `endpoint`, `attempt`, `status`) and debug events on retry (backoff delay,
+  transient status/error). Off by default; adds no dependency when disabled.
+  ```toml
+  datamaxi = { git = "https://github.com/bisonai/datamaxi-rust.git", features = ["tracing"] }
+  ```
+- **Custom HTTP client** — `ClientBuilder::http_client` (and the `blocking`
+  mirror) let you supply your own pre-built `reqwest::Client`, e.g. wrapped
+  with `reqwest-middleware` for custom auth, metrics, or logging:
+  ```rust,ignore
+  let http = reqwest::Client::builder().build()?;
+  let client = ClientBuilder::new().api_key("my_api_key").http_client(http).build()?;
+  ```
+
 ### Minimum Supported Rust Version (MSRV)
 
 This crate requires **Rust 1.86** or newer. The MSRV is verified in CI and

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,3 +1,20 @@
+//! ## Observability
+//!
+//! Two independent, additive, opt-in hooks:
+//!
+//! - **`tracing` feature** — instruments [`Client::get`] / [`blocking::Client::get`]
+//!   with a span (`method`, `endpoint`, `attempt`, `status`) and debug events on
+//!   each retry (backoff delay, transient status/error). Off by default and
+//!   compiles away entirely (no `tracing` dependency pulled in) when disabled.
+//!   The API key is never recorded — [`Client`]'s `Debug` impl already redacts
+//!   it, and no span/event field ever carries it.
+//! - **Custom HTTP client** — [`ClientBuilder::http_client`] /
+//!   [`blocking::ClientBuilder::http_client`] let callers supply their own
+//!   pre-built `reqwest::Client`, e.g. wrapped with `reqwest-middleware` for
+//!   custom auth, metrics, or logging middleware. When omitted, the client
+//!   falls back to the built-in defaults (`User-Agent`, unbounded idle pool,
+//!   the configured timeout).
+
 use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
 use std::collections::BTreeMap;
@@ -237,6 +254,9 @@ macro_rules! get_loop {
         let mut attempt: u32 = 0;
 
         loop {
+            #[cfg(feature = "tracing")]
+            tracing::Span::current().record("attempt", attempt as u64);
+
             let mut request = $self
                 .inner_client
                 .get(url.as_str())
@@ -249,12 +269,23 @@ macro_rules! get_loop {
             match request.send()$(.$aw)? {
                 Ok(response) => {
                     let status = response.status();
+                    #[cfg(feature = "tracing")]
+                    tracing::Span::current().record("status", status.as_u16() as u64);
+
                     if attempt < $self.retry.max_retries && is_retryable_status(status) {
                         let delay = retry_delay_for_response(
                             &$self.retry,
                             status,
                             response.headers(),
                             attempt,
+                        );
+                        #[cfg(feature = "tracing")]
+                        tracing::debug!(
+                            target: "datamaxi::retry",
+                            attempt = attempt as u64,
+                            status = status.as_u16() as u64,
+                            delay_ms = delay.as_millis() as u64,
+                            "retrying transient response"
                         );
                         attempt += 1;
                         $sleep(delay)$(.$aw)?;
@@ -265,10 +296,20 @@ macro_rules! get_loop {
                 Err(error) => {
                     if attempt < $self.retry.max_retries && is_retryable_error(&error) {
                         let delay = backoff_delay(&$self.retry, attempt);
+                        #[cfg(feature = "tracing")]
+                        tracing::debug!(
+                            target: "datamaxi::retry",
+                            attempt = attempt as u64,
+                            delay_ms = delay.as_millis() as u64,
+                            error = %error,
+                            "retrying after transport error"
+                        );
                         attempt += 1;
                         $sleep(delay)$(.$aw)?;
                         continue;
                     }
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(target: "datamaxi::retry", error = %error, "request failed");
                     return Err(Error::from(error));
                 }
             }
@@ -332,6 +373,19 @@ impl Client {
     /// retried per the client's [`RetryConfig`] with exponential backoff; a
     /// `429` honors its `Retry-After` header. Fatal statuses
     /// (`400`/`401`/`403`/`404`) are returned without retry.
+    ///
+    /// With the `tracing` feature enabled, each call is wrapped in a span
+    /// carrying `method`, `endpoint`, `attempt`, and the resolved `status`;
+    /// retries additionally emit a debug event with the backoff delay. The
+    /// API key is never recorded.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "datamaxi.get",
+            skip(self, parameters),
+            fields(method = "GET", attempt = tracing::field::Empty, status = tracing::field::Empty)
+        )
+    )]
     pub async fn get<T: DeserializeOwned>(
         &self,
         endpoint: &str,
@@ -410,6 +464,7 @@ async fn handle_response<T: DeserializeOwned>(response: reqwest::Response) -> Re
 #[derive(Debug, Clone)]
 pub struct ClientBuilder {
     state: BuilderState,
+    http_client: Option<reqwest::Client>,
 }
 
 impl ClientBuilder {
@@ -418,6 +473,7 @@ impl ClientBuilder {
     pub fn new() -> Self {
         ClientBuilder {
             state: BuilderState::new(),
+            http_client: None,
         }
     }
 
@@ -454,17 +510,33 @@ impl ClientBuilder {
         self
     }
 
+    /// Overrides the internally-built `reqwest::Client` with a caller-supplied
+    /// one — the escape hatch for custom middleware, timeouts, proxies, or
+    /// instrumentation (e.g. a `reqwest-middleware` client wrapped down to its
+    /// inner `reqwest::Client`, or one built with `reqwest_tracing`).
+    ///
+    /// When set, [`ClientBuilder::timeout`] is ignored for HTTP-level
+    /// settings (the caller's client is used as-is); [`build`](Self::build)
+    /// no longer applies the built-in `User-Agent` / pool defaults.
+    pub fn http_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = Some(client);
+        self
+    }
+
     /// Builds the [`Client`].
     ///
     /// Resolves the API key from the explicit value or the `DATAMAXI_API_KEY`
     /// environment variable, returning [`Error::MissingApiKey`] if neither is set.
     pub fn build(self) -> Result<Client> {
         let resolved = self.state.resolve()?;
+        let inner_client = self
+            .http_client
+            .unwrap_or_else(|| build_inner_client(resolved.timeout));
 
         Ok(Client {
             base_url: resolved.base_url,
             api_key: resolved.api_key,
-            inner_client: build_inner_client(resolved.timeout),
+            inner_client,
             retry: resolved.retry,
         })
     }
@@ -604,6 +676,19 @@ pub mod blocking {
         /// per the client's retry config with exponential backoff (a `429`
         /// honors `Retry-After`); fatal statuses are returned without retry.
         /// Backoff waits use a blocking [`std::thread::sleep`].
+        ///
+        /// With the `tracing` feature enabled, each call is wrapped in a span
+        /// carrying `method`, `endpoint`, `attempt`, and the resolved
+        /// `status`; retries additionally emit a debug event with the
+        /// backoff delay. The API key is never recorded.
+        #[cfg_attr(
+            feature = "tracing",
+            tracing::instrument(
+                name = "datamaxi.get",
+                skip(self, parameters),
+                fields(method = "GET", attempt = tracing::field::Empty, status = tracing::field::Empty)
+            )
+        )]
         pub fn get<T: DeserializeOwned>(
             &self,
             endpoint: &str,
@@ -650,6 +735,7 @@ pub mod blocking {
     #[derive(Debug, Clone)]
     pub struct ClientBuilder {
         state: BuilderState,
+        http_client: Option<reqwest::blocking::Client>,
     }
 
     impl ClientBuilder {
@@ -657,6 +743,7 @@ pub mod blocking {
         pub fn new() -> Self {
             ClientBuilder {
                 state: BuilderState::new(),
+                http_client: None,
             }
         }
 
@@ -692,15 +779,26 @@ pub mod blocking {
             self
         }
 
+        /// Overrides the internally-built `reqwest::blocking::Client` with a
+        /// caller-supplied one. Mirrors [`super::ClientBuilder::http_client`]
+        /// for the blocking flavor.
+        pub fn http_client(mut self, client: reqwest::blocking::Client) -> Self {
+            self.http_client = Some(client);
+            self
+        }
+
         /// Builds the blocking [`Client`], resolving the API key from the
         /// explicit value or the `DATAMAXI_API_KEY` environment variable.
         pub fn build(self) -> Result<Client> {
             let resolved = self.state.resolve()?;
+            let inner_client = self
+                .http_client
+                .unwrap_or_else(|| build_inner_client(resolved.timeout));
 
             Ok(Client {
                 base_url: resolved.base_url,
                 api_key: resolved.api_key,
-                inner_client: build_inner_client(resolved.timeout),
+                inner_client,
                 retry: resolved.retry,
             })
         }

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -592,6 +592,82 @@ fn client_builder_without_key_errors() {
     );
 }
 
+/// `ClientBuilder::http_client` (issue #89) overrides the internally-built
+/// `reqwest::Client`. Proven by supplying a client with a custom `User-Agent`
+/// and asserting the mock server sees that value instead of the default
+/// `datamaxi-rust/<ver>` one — the escape hatch for custom middleware.
+#[tokio::test]
+async fn client_builder_http_client_overrides_inner_client() {
+    let mut server = mockito::Server::new_async().await;
+
+    let mock = server
+        .mock("GET", "/api/v1/cex/candle/exchanges")
+        .match_header("X-DTMX-APIKEY", API_KEY)
+        .match_header("user-agent", "my-custom-middleware-client/1.0")
+        .match_query(Matcher::UrlEncoded("market".into(), "spot".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("[]")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let custom = reqwest::Client::builder()
+        .user_agent("my-custom-middleware-client/1.0")
+        .build()
+        .expect("custom reqwest client builds");
+
+    let client = ClientBuilder::new()
+        .api_key(API_KEY)
+        .base_url(server.url())
+        .http_client(custom)
+        .build()
+        .expect("client with custom http_client should build");
+    let res = client
+        .cex_candle()
+        .exchanges(CexCandleExchangesMarket::Spot)
+        .await;
+
+    mock.assert_async().await;
+    assert!(res.is_ok(), "expected Ok, got {:?}", res);
+}
+
+/// Blocking mirror of [`client_builder_http_client_overrides_inner_client`].
+#[cfg(feature = "blocking")]
+#[test]
+fn blocking_client_builder_http_client_overrides_inner_client() {
+    let mut server = mockito::Server::new();
+
+    let mock = server
+        .mock("GET", "/api/v1/cex/candle/exchanges")
+        .match_header("X-DTMX-APIKEY", API_KEY)
+        .match_header("user-agent", "my-custom-blocking-client/1.0")
+        .match_query(Matcher::UrlEncoded("market".into(), "spot".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("[]")
+        .expect(1)
+        .create();
+
+    let custom = reqwest::blocking::Client::builder()
+        .user_agent("my-custom-blocking-client/1.0")
+        .build()
+        .expect("custom blocking reqwest client builds");
+
+    let client = datamaxi::api::blocking::ClientBuilder::new()
+        .api_key(API_KEY)
+        .base_url(server.url())
+        .http_client(custom)
+        .build()
+        .expect("blocking client with custom http_client should build");
+    let res = client
+        .cex_candle()
+        .exchanges(CexCandleExchangesMarket::Spot);
+
+    mock.assert();
+    assert!(res.is_ok(), "expected Ok, got {:?}", res);
+}
+
 // --- Blocking feature smoke tests ------------------------------------------
 
 /// The `blocking` mirror exposes the same endpoints synchronously and routes
@@ -1233,4 +1309,92 @@ async fn funding_rate_exchanges_decodes_string_vec() {
         .expect("exchanges list decodes");
 
     assert_eq!(exchanges, vec!["binance", "bybit", "okx"]);
+}
+
+// --- tracing (issue #89) ----------------------------------------------------
+//
+// Proves the `tracing` feature actually emits: a minimal `Subscriber` counts
+// events, and a retried request (via the blocking client, to avoid needing an
+// async-aware subscriber) must produce at least the "retrying transient
+// response" debug event emitted by `get_loop!`.
+
+#[cfg(all(feature = "tracing", feature = "blocking"))]
+mod tracing_smoke {
+    use super::API_KEY;
+    use datamaxi::LiquidationHeatmapOptions;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tracing::span::{Attributes, Id, Record};
+    use tracing::{Event, Metadata, Subscriber};
+
+    /// Counts every `event!` (e.g. `tracing::debug!`) delivered to it; ignores
+    /// span lifecycle calls (a fixed dummy `Id` is fine since nothing here
+    /// inspects span identity).
+    struct CountingSubscriber {
+        events: Arc<AtomicUsize>,
+    }
+
+    impl Subscriber for CountingSubscriber {
+        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _span: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+        fn event(&self, _event: &Event<'_>) {
+            self.events.fetch_add(1, Ordering::SeqCst);
+        }
+        fn enter(&self, _span: &Id) {}
+        fn exit(&self, _span: &Id) {}
+    }
+
+    /// A retried `503` (followed by a `200`) must emit `get_loop!`'s "retrying
+    /// transient response" debug event under the `tracing` feature.
+    #[test]
+    fn retry_emits_tracing_event() {
+        let mut server = mockito::Server::new();
+        let fail = server
+            .mock("GET", "/api/v1/liquidation/heatmap")
+            .with_status(503)
+            .with_body("unavailable")
+            .expect(1)
+            .create();
+        let ok = server
+            .mock("GET", "/api/v1/liquidation/heatmap")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("{}")
+            .expect(1)
+            .create();
+
+        let client = datamaxi::api::blocking::ClientBuilder::new()
+            .api_key(API_KEY)
+            .base_url(server.url())
+            .max_retries(1)
+            .retry_base_delay(Duration::from_millis(1))
+            .build()
+            .expect("mock retry client builds");
+
+        let events = Arc::new(AtomicUsize::new(0));
+        let subscriber = CountingSubscriber {
+            events: events.clone(),
+        };
+
+        let res = tracing::subscriber::with_default(subscriber, || {
+            client
+                .liquidation()
+                .heatmap(LiquidationHeatmapOptions::new())
+        });
+
+        fail.assert();
+        ok.assert();
+        assert!(res.is_ok(), "expected Ok after retry, got {:?}", res);
+        assert!(
+            events.load(Ordering::SeqCst) > 0,
+            "expected at least one tracing event emitted during retry"
+        );
+    }
 }


### PR DESCRIPTION
Closes #89

Adds two additive, opt-in observability hooks. No breaking changes; `src/generated.rs` untouched.

## 1. tracing (optional `tracing` feature, off by default)
- New optional `tracing` dep gated by a `tracing` cargo feature (`dep:tracing`); compiles away entirely when off.
- `Client::get` / `blocking::Client::get` open a per-call span via `#[cfg_attr(feature = "tracing", tracing::instrument(...))]` recording `method`, `endpoint`, `attempt`, `status`.
- The shared `get_loop!` retry macro emits `debug!`/`warn!` events on retry (with `delay_ms`) and on terminal transport error — one emit point covering async + blocking.
- API key is never referenced by any span/event (Debug-redaction invariant preserved).

## 2. Custom HTTP client hook (middleware escape hatch)
- New `ClientBuilder::http_client(reqwest::Client)` / `blocking::ClientBuilder::http_client(reqwest::blocking::Client)`. When supplied, `build()` uses it; otherwise falls back to the default-built client (User-Agent, unbounded idle pool, timeout unchanged). Lets callers inject their own middleware/instrumentation.
- Went with the minimal custom-client hook per the issue's "simplest path"; no `reqwest-middleware` dependency.

## Tests
- `tests/wire_contract.rs`: `http_client` override proven via a custom User-Agent seen by the mock server (async + blocking); `tracing_smoke` test (gated on `tracing`+`blocking`) proves a retried request emits a tracing event via a minimal counting subscriber.
- README gains an Observability section.

## Verification
- Builds: default, `--features tracing`, `--all-features` — all pass
- `cargo test --all-features` (lib + wire_contract 44/44 + doc) — pass
- clippy (default, `tracing`, all-features) `-D warnings` — clean; `fmt --check` — clean
- One pre-existing `live.rs` flake under concurrent load (CI runs `--test-threads=1`), unrelated to this change