### PR TITLE
test: drop redundant per-field decode asserts from wire_contract.rs

### DIFF
--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -993,23 +993,16 @@ fn blocking_status_429_surfaces_retry_after_seconds() {
 
 // --- Deep response deserialization (issue #64) -----------------------------
 //
-// The tests above prove the OUTBOUND contract (path/query/auth) and that a
-// response *decodes* — but they feed empty `{}`/`[]` bodies, so struct-level
-// `#[serde(default)]` masks any field-level decode bug. The tests below mock
-// REALISTIC non-empty JSON and assert decoded field VALUES and types across
-// each distinct response shape:
-//   * object response            → `CexCandleResponse`, `FundingRateLatestResponse`, `ForexResponse`
-//   * `Vec<View>` response       → `CexSymbolLiquidationView`, `CexFeesView`
-//   * scalar `Vec<String>`       → `funding_rate().exchanges()`
-// They specifically lock the `#[serde(rename)]` short keys (candle c/d/h/l/o/v,
-// forex d/r/s, funding b/d/e/f/i/id/q/s) and `Option<f64>`/`Option<i64>`
-// nullable fields BOTH present (`Some`) and absent (`None`). A codegen regen
-// that drops a `rename` or flips a type would fail here, not silently pass.
+// The tests above prove the OUTBOUND contract (path/query/auth). The tests
+// below mock REALISTIC non-empty JSON (rather than empty `{}`/`[]`, which
+// `#[serde(default)]` would trivially satisfy) and assert the response
+// decodes successfully with the right shape. Per-field VALUE assertions on
+// generated struct fields (renamed keys, `Option` present/absent) are now
+// covered by `tests/generated_contract.rs`'s serde round-trip tests, which
+// don't couple to field names and can't break on a codegen rename/retype.
 
-/// Object response with a nested `Vec<CexCandleView>` whose fields are the
-/// renamed one-letter keys `c`/`d`/`h`/`l`/`o`/`v`. Asserts the top-level
-/// envelope AND every renamed candle field decodes to the right value — proving
-/// the `#[serde(rename)]` map, not just "decode didn't panic".
+/// Object response with a nested `Vec<CexCandleView>` decodes successfully
+/// from realistic renamed-key (`c`/`d`/`h`/`l`/`o`/`v`) JSON.
 #[tokio::test]
 async fn cex_candle_decodes_renamed_ohlcv_fields() {
     let mut server = mockito::Server::new_async().await;
@@ -1048,28 +1041,11 @@ async fn cex_candle_decodes_renamed_ohlcv_fields() {
         .await
         .expect("realistic candle body decodes");
 
-    assert_eq!(resp.currency, "USD");
-    assert_eq!(resp.exchange, "binance");
-    assert_eq!(resp.interval, "1h");
-    assert_eq!(resp.market, "spot");
-    assert_eq!(resp.symbol, "BTC-USDT");
     assert_eq!(resp.data.len(), 2);
-
-    let first = &resp.data[0];
-    assert_eq!(first.close, 100.5); // renamed "c"
-    assert_eq!(first.timestamp, 1_700_000_000); // renamed "d"
-    assert_eq!(first.high, 110.0); // renamed "h"
-    assert_eq!(first.low, 90.0); // renamed "l"
-    assert_eq!(first.open, 95.0); // renamed "o"
-    assert_eq!(first.volume, 1234.5); // renamed "v"
-
-    assert_eq!(resp.data[1].close, 101.5);
-    assert_eq!(resp.data[1].open, 100.5);
 }
 
 /// Object response with renamed keys AND nullable `Option<f64>`/`Option<i64>`
-/// fields PRESENT. `funding_rate` (`f`) and `interval_hours` (`i`) carry values,
-/// so both must decode to `Some(..)`.
+/// fields PRESENT (`f`/`i`) decodes successfully.
 #[tokio::test]
 async fn funding_rate_latest_decodes_nullable_fields_present() {
     let mut server = mockito::Server::new_async().await;
@@ -1094,26 +1070,21 @@ async fn funding_rate_latest_decodes_nullable_fields_present() {
         .create_async()
         .await;
 
-    let resp = mock_client(server.url())
+    let res = mock_client(server.url())
         .funding_rate()
         .latest("binance", "BTC-USDT")
-        .await
-        .expect("funding-rate latest body decodes");
+        .await;
 
-    assert_eq!(resp.base, "BTC"); // renamed "b"
-    assert_eq!(resp.timestamp, 1_700_000_000); // renamed "d"
-    assert_eq!(resp.exchange, "binance"); // renamed "e"
-    assert_eq!(resp.funding_rate, Some(0.0001)); // renamed "f", present
-    assert_eq!(resp.interval_hours, Some(8)); // renamed "i", present
-    assert_eq!(resp.token_id, "binance-btc-usdt"); // renamed "id"
-    assert_eq!(resp.quote, "USDT"); // renamed "q"
-    assert_eq!(resp.symbol, "BTC-USDT"); // renamed "s"
+    assert!(
+        res.is_ok(),
+        "funding-rate latest body decodes, got {:?}",
+        res
+    );
 }
 
-/// Same shape as above but the nullable keys are ABSENT from the payload. With
-/// `#[serde(default)]` they must decode to `None` (not a zero value), while the
-/// required string/int fields still populate. This is the "absent → None" half
-/// of the nullable contract that an empty-body test can never exercise.
+/// Same shape as above but the nullable keys (`f`/`i`) are ABSENT from the
+/// payload. With `#[serde(default)]` the response must still decode
+/// successfully rather than erroring on the missing keys.
 #[tokio::test]
 async fn funding_rate_latest_decodes_nullable_fields_absent() {
     let mut server = mockito::Server::new_async().await;
@@ -1137,23 +1108,21 @@ async fn funding_rate_latest_decodes_nullable_fields_absent() {
         .create_async()
         .await;
 
-    let resp = mock_client(server.url())
+    let res = mock_client(server.url())
         .funding_rate()
         .latest("bybit", "ETH-USDT")
-        .await
-        .expect("funding-rate latest body (nulls absent) decodes");
+        .await;
 
-    assert_eq!(resp.base, "ETH");
-    assert_eq!(resp.exchange, "bybit");
-    assert_eq!(resp.token_id, "bybit-eth-usdt");
-    assert_eq!(resp.funding_rate, None); // absent → None
-    assert_eq!(resp.interval_hours, None); // absent → None
+    assert!(
+        res.is_ok(),
+        "funding-rate latest body (nulls absent) decodes, got {:?}",
+        res
+    );
 }
 
-/// `Vec<View>` response: a top-level JSON array of `CexSymbolLiquidationView`.
-/// The two elements exercise the `Option<f64>` USD fields BOTH present (element
-/// 0) and absent (element 1) within a single decoded vector, alongside the
-/// always-present `f64` volume fields.
+/// `Vec<View>` response: a top-level JSON array of `CexSymbolLiquidationView`
+/// decodes successfully, with elements mixing `Option<f64>` USD fields
+/// present (element 0) and absent (element 1).
 #[tokio::test]
 async fn cex_symbol_liquidation_decodes_vec_with_present_and_absent_nullables() {
     let mut server = mockito::Server::new_async().await;
@@ -1191,28 +1160,11 @@ async fn cex_symbol_liquidation_decodes_vec_with_present_and_absent_nullables() 
         .expect("liquidation array decodes");
 
     assert_eq!(rows.len(), 2);
-
-    let btc = &rows[0];
-    assert_eq!(btc.base, "BTC");
-    assert_eq!(btc.exchange, "binance");
-    assert_eq!(btc.market, "futures");
-    assert_eq!(btc.event_count, 12);
-    assert_eq!(btc.long_volume, 100.0);
-    assert_eq!(btc.long_volume_usd, Some(4_200_000.0)); // present
-    assert_eq!(btc.short_volume_usd, Some(2_100_000.0));
-    assert_eq!(btc.total_volume_usd, Some(6_300_000.0));
-
-    let eth = &rows[1];
-    assert_eq!(eth.base, "ETH");
-    assert_eq!(eth.total_volume, 15.0);
-    assert_eq!(eth.long_volume_usd, None); // absent → None
-    assert_eq!(eth.short_volume_usd, None);
-    assert_eq!(eth.total_volume_usd, None);
 }
 
 /// `Vec<View>` response of `CexFeesView`, again mixing present/absent
-/// `Option<f64>` fee fields. Broadens coverage to the `/cex/fees` endpoint
-/// (reached via the `trading_fees()` accessor).
+/// `Option<f64>` fee fields, decodes successfully. Broadens coverage to the
+/// `/cex/fees` endpoint (reached via the `trading_fees()` accessor).
 #[tokio::test]
 async fn cex_fees_decodes_vec_with_present_and_absent_nullables() {
     let mut server = mockito::Server::new_async().await;
@@ -1245,22 +1197,11 @@ async fn cex_fees_decodes_vec_with_present_and_absent_nullables() {
         .expect("fees array decodes");
 
     assert_eq!(fees.len(), 2);
-
-    let btc = &fees[0];
-    assert_eq!(btc.symbol, "BTC-USDT");
-    assert_eq!(btc.spot_maker_fee, Some(0.001));
-    assert_eq!(btc.futures_maker_fee, Some(0.0002)); // present
-    assert_eq!(btc.futures_taker_fee, Some(0.0005));
-
-    let eth = &fees[1];
-    assert_eq!(eth.symbol, "ETH-USDT");
-    assert_eq!(eth.spot_maker_fee, Some(0.001));
-    assert_eq!(eth.futures_maker_fee, None); // absent → None
-    assert_eq!(eth.futures_taker_fee, None);
 }
 
-/// Object response `ForexResponse` with the renamed keys `d`/`r`/`s`. Small but
-/// distinct shape (flat object, no nested vec) and a new endpoint (`/forex`).
+/// Object response `ForexResponse` with the renamed keys `d`/`r`/`s` decodes
+/// successfully. Small but distinct shape (flat object, no nested vec) and a
+/// new endpoint (`/forex`).
 #[tokio::test]
 async fn forex_decodes_renamed_fields() {
     let mut server = mockito::Server::new_async().await;
@@ -1276,15 +1217,9 @@ async fn forex_decodes_renamed_fields() {
         .create_async()
         .await;
 
-    let resp = mock_client(server.url())
-        .forex()
-        .get("USD/KRW")
-        .await
-        .expect("forex body decodes");
+    let res = mock_client(server.url()).forex().get("USD/KRW").await;
 
-    assert_eq!(resp.timestamp, 1_700_000_000); // renamed "d"
-    assert_eq!(resp.rate, 1350.25); // renamed "r"
-    assert_eq!(resp.symbol, "USD/KRW"); // renamed "s"
+    assert!(res.is_ok(), "forex body decodes, got {:?}", res);
 }
 
 /// Scalar `Vec<String>` response: the funding-rate `exchanges` list. Asserts the


### PR DESCRIPTION
Closes #93

## Summary
- Removed hand-written per-field decode `assert_eq!` calls on generated response structs (candle OHLCV, funding-rate rename+nullable fields, cex-symbol-liquidation view, cex-fees view, forex rename fields) from `tests/wire_contract.rs`. These are now covered by the generated `tests/generated_contract.rs` serde round-trip tests (added in #94), which validate wire-key/rename/type mapping without naming struct fields, so a codegen rename/retype can no longer break the sync PR.
- Kept every test's routing/behavioral intent: each edited test still hits the right endpoint and asserts the response decodes successfully (`res.is_ok()` / collection `.len()`), preserving endpoint-routing coverage.
- Did not delete any tests — all 44 `wire_contract.rs` tests still exist and pass, just with fewer per-field assertions.
- Untouched: retry/backoff, Retry-After parsing, error-status mapping, pagination, `http_client` override, tracing smoke, snake_case query-key guards, `ClientBuilder` tests.
- No changes to `src/`, `tests/generated_contract.rs`, or `tests/pagination.rs`.

Grep-invariant confirmed: no generated response-field accesses remain in `tests/wire_contract.rs` (only `.data.len()` / `.len()` collection-length checks and builder/accessor method calls like `.market(...)`, `.exchange(...)`, `.funding_rate()` remain).

Note: my worktree branched off main before PR #94 (which added `tests/generated_contract.rs`) merged, so I fast-forwarded to current `origin/main` (no conflicts, no rebase) to pick that file up before doing this surgery.

## Test plan
- [x] `cargo test --all-features` — pass (`wire_contract`: 44 passed; `generated_contract`: 63 passed; `pagination`: 4 passed). `tests/live.rs` has 2 pre-existing network-flake failures (`live_index_price_get`, `live_cex_candle_get`, timeouts hitting the real API) unrelated to this change.
- [x] `cargo test` (default features) — pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean