### PR TITLE
test: complete mock fixtures for strict required-field decode (pre codegen#86)

### DIFF
--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -32,7 +32,7 @@ fn page_body(page: i64, limit: i64, total: i64, n: usize) -> String {
         })
         .collect();
     format!(
-        r#"{{"data":[{}],"limit":{limit},"page":{page},"total":{total}}}"#,
+        r#"{{"category":[],"data":[{}],"exchange":[],"limit":{limit},"page":{page},"sort":"x","total":{total}}}"#,
         data.join(",")
     )
 }

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -23,6 +23,13 @@ use mockito::Matcher;
 
 const API_KEY: &str = "test-api-key";
 
+/// Minimal but COMPLETE `LiquidationHeatmapResponse` envelope: every required
+/// field present (empty arrays are valid instances of the required `Vec`
+/// fields), so this decodes under both lax (struct-level `#[serde(default)]`)
+/// and strict (per-field only) generated code.
+const HEATMAP_BODY: &str =
+    r#"{"cells":[],"exchanges":[],"generatedAt":0,"grandTotal":0.0,"tokens":[],"window":"1h"}"#;
+
 /// Build an async client pointed at the mock server (explicit key + base URL),
 /// exercising the new root-client construction + accessor path the SDK exposes.
 fn mock_client(base_url: String) -> Client {
@@ -58,7 +65,7 @@ async fn liquidation_heatmap_sends_top_n_window_and_apikey() {
         ]))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body("{}")
+        .with_body(HEATMAP_BODY)
         .expect(1)
         .create_async()
         .await;
@@ -86,7 +93,9 @@ async fn liquidation_stats_sends_min_volume_usd() {
             Matcher::UrlEncoded("window".into(), "24h".into()),
         ]))
         .with_status(200)
-        .with_body("{}")
+        .with_body(
+            r#"{"count":1,"generatedAt":0,"longRatio":0,"longUsd":0.0,"shortUsd":0.0,"total":0.0,"venues":0,"window":"24h"}"#,
+        )
         .expect(1)
         .create_async()
         .await;
@@ -117,7 +126,9 @@ async fn cex_candle_sends_required_and_optional_keys() {
             Matcher::UrlEncoded("currency".into(), "USD".into()),
         ]))
         .with_status(200)
-        .with_body("{}")
+        .with_body(
+            r#"{"currency":"USD","data":[],"exchange":"binance","interval":"1h","market":"spot","symbol":"BTC-USDT"}"#,
+        )
         .expect(1)
         .create_async()
         .await;
@@ -155,7 +166,9 @@ async fn query_params_are_percent_encoded() {
         ]))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body("{}")
+        .with_body(
+            r#"{"currency":"USD","data":[],"exchange":"binance","interval":"1h","market":"spot","symbol":"BTC-USDT"}"#,
+        )
         .expect(1)
         .create_async()
         .await;
@@ -193,9 +206,9 @@ async fn call_with_status(
 
 #[tokio::test]
 async fn status_200_maps_to_ok() {
-    // Body deserializes into the typed `LiquidationHeatmapResponse`; struct-level
-    // serde default lets an empty `{}` payload decode with zero-valued fields.
-    let res = call_with_status(200, "{}").await;
+    // Body deserializes into the typed `LiquidationHeatmapResponse`; a complete
+    // envelope (every required field present) decodes under strict decode too.
+    let res = call_with_status(200, HEATMAP_BODY).await;
     assert!(res.is_ok(), "200 should map to Ok, got {:?}", res);
 }
 
@@ -406,7 +419,9 @@ async fn open_interest_summary_sends_top_n() {
         .match_query(Matcher::UrlEncoded("top_n".into(), "5".into()))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body("{}")
+        .with_body(
+            r#"{"exchanges":[],"generatedAt":0,"grandTotal":0.0,"tokens":[],"totalTokens":0}"#,
+        )
         .expect(1)
         .create_async()
         .await;
@@ -467,7 +482,7 @@ async fn premium_sends_snake_keys() {
         ]))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body("{}")
+        .with_body(r#"{"data":[],"limit":1,"page":1,"sort":"x","total":0}"#)
         .expect(1)
         .create_async()
         .await;
@@ -500,7 +515,7 @@ async fn root_client_accessors_share_one_client() {
         .match_query(Matcher::UrlEncoded("window".into(), "1h".into()))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body("{}")
+        .with_body(HEATMAP_BODY)
         .expect(1)
         .create_async()
         .await;
@@ -705,7 +720,7 @@ fn blocking_liquidation_heatmap_smoke() {
         .match_query(Matcher::UrlEncoded("window".into(), "1h".into()))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body("{}")
+        .with_body(HEATMAP_BODY)
         .expect(1)
         .create();
 
@@ -752,7 +767,7 @@ async fn retry_then_succeed_on_5xx() {
         .mock("GET", "/api/v1/liquidation/heatmap")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body("{}")
+        .with_body(HEATMAP_BODY)
         .expect(1)
         .create_async()
         .await;
@@ -784,7 +799,7 @@ async fn retry_then_succeed_on_429_with_retry_after() {
         .mock("GET", "/api/v1/liquidation/heatmap")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body("{}")
+        .with_body(HEATMAP_BODY)
         .expect(1)
         .create_async()
         .await;
@@ -867,7 +882,7 @@ fn blocking_retry_then_succeed_on_5xx() {
         .mock("GET", "/api/v1/liquidation/heatmap")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body("{}")
+        .with_body(HEATMAP_BODY)
         .expect(1)
         .create();
 
@@ -1320,7 +1335,7 @@ async fn funding_rate_exchanges_decodes_string_vec() {
 
 #[cfg(all(feature = "tracing", feature = "blocking"))]
 mod tracing_smoke {
-    use super::API_KEY;
+    use super::{API_KEY, HEATMAP_BODY};
     use datamaxi::LiquidationHeatmapOptions;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -1366,7 +1381,7 @@ mod tracing_smoke {
             .mock("GET", "/api/v1/liquidation/heatmap")
             .with_status(200)
             .with_header("content-type", "application/json")
-            .with_body("{}")
+            .with_body(HEATMAP_BODY)
             .expect(1)
             .create();
 


### PR DESCRIPTION
Pre-empts codegen#86 (Bisonai/datamaxi-codegen#78), which drops the blanket `#[serde(default)]` so response structs hard-error on missing **required** fields. Several hand-written mock payloads in these two test files were incomplete (relied on the old default) and would fail strict decode once #86 syncs in. This completes them so main stays green when #86 lands.

## Changes (test files only)
- `tests/wire_contract.rs`: added a shared complete `HEATMAP_BODY` const (reused by 7 heatmap/retry/tracing tests that shipped `"{}"`); completed the `LiquidationStats`, `CexCandle`, `OpenInterestSummary`, and `Premium` response envelopes with their now-required fields.
- `tests/pagination.rs`: added required envelope fields (`category`, `exchange`, `sort`) to the `CexAnnouncementsResponse` mock.

Intentionally-absent `Option` fields left absent (they stay optional under #78).

## Verification
- Verified against a **strict-regenerated** `generated.rs`+`generated_contract.rs` from codegen#78's head AND the current (lax) code — full suite passes both ways (wire_contract 44, pagination 4, generated_contract 126/13, lib).
- `clippy -D warnings` + `fmt --check` clean. Diff touches only the two test files.
- No over-marked-required conflicts: every field a test omits to assert `None` is genuinely `Option<T>` in both lax and strict generated code.

Must merge BEFORE codegen#78 syncs into this repo.