### PR TITLE
Sync generated Rust with backend spec

### DIFF
--- a/src/generated.rs
+++ b/src/generated.rs
@@ -7,15 +7,17 @@ use std::collections::BTreeMap;
 // --- Response models ---
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexAnnouncementsResponse {
     /// specifies the exchanges of the announcements
+    #[serde(default)]
     pub category: Vec<String>,
     /// `Data` specifies an array of the announcements
     pub data: Vec<CexAnnouncementsView>,
     /// specifies the categories of the announcements
+    #[serde(default)]
     pub exchange: Vec<String>,
+    #[serde(default)]
     pub key: Option<String>,
     pub limit: i64,
     pub page: i64,
@@ -24,7 +26,6 @@ pub struct CexAnnouncementsResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexAnnouncementsView {
     /// specifies the category of the announcement
@@ -48,7 +49,6 @@ pub struct CexAnnouncementsView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexCandleResponse {
     pub currency: String,
@@ -60,7 +60,6 @@ pub struct CexCandleResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexCandleSymbolsView {
     /// specifies the base symbol
@@ -83,7 +82,6 @@ pub struct CexCandleSymbolsView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexCandleView {
     /// specifies close price of the candle
@@ -107,7 +105,6 @@ pub struct CexCandleView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexFeesView {
     /// specifies base symbol
@@ -115,21 +112,24 @@ pub struct CexFeesView {
     /// specifies exchange
     pub exchange: String,
     /// specifies maker fee percentage for futures market
+    #[serde(default)]
     pub futures_maker_fee: Option<f64>,
     /// specifies taker fee percentage for futures market
+    #[serde(default)]
     pub futures_taker_fee: Option<f64>,
     /// specifies quote symbol
     pub quote: String,
     /// specifies maker fee percentage for spot market (e.g. 0.001 = 0.1%)
+    #[serde(default)]
     pub spot_maker_fee: Option<f64>,
     /// specifies taker fee percentage for spot market
+    #[serde(default)]
     pub spot_take_fee: Option<f64>,
     /// specifies symbol
     pub symbol: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexSymbolCautionsView {
     #[serde(rename = "b")]
@@ -139,16 +139,17 @@ pub struct CexSymbolCautionsView {
     #[serde(rename = "e")]
     pub exchange: String,
     /// ms, 0 = indefinite
+    #[serde(default)]
     pub end_at: Option<i64>,
     #[serde(rename = "m")]
     pub market: String,
     #[serde(rename = "q")]
     pub quote: String,
+    #[serde(default)]
     pub reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexSymbolDelistingsView {
     #[serde(rename = "b")]
@@ -158,6 +159,7 @@ pub struct CexSymbolDelistingsView {
     #[serde(rename = "e")]
     pub exchange: String,
     /// ms
+    #[serde(default)]
     pub listed_at: Option<i64>,
     #[serde(rename = "m")]
     pub market: String,
@@ -168,7 +170,6 @@ pub struct CexSymbolDelistingsView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexSymbolLiquidationView {
     #[serde(rename = "b")]
@@ -177,6 +178,7 @@ pub struct CexSymbolLiquidationView {
     pub exchange: String,
     pub event_count: i64,
     pub long_volume: f64,
+    #[serde(default)]
     pub long_volume_usd: Option<f64>,
     /// always "futures"
     #[serde(rename = "m")]
@@ -184,25 +186,31 @@ pub struct CexSymbolLiquidationView {
     #[serde(rename = "q")]
     pub quote: String,
     pub short_volume: f64,
+    #[serde(default)]
     pub short_volume_usd: Option<f64>,
     pub total_volume: f64,
+    #[serde(default)]
     pub total_volume_usd: Option<f64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexSymbolMetadataView {
     #[serde(rename = "b")]
     pub base: String,
     /// ms
+    #[serde(default)]
     pub caution_end_at: Option<i64>,
     /// "", caution, warning, danger
+    #[serde(default)]
     pub caution_level: Option<String>,
+    #[serde(default)]
     pub caution_reasons: Vec<String>,
+    #[serde(default)]
     pub delisting_at: Option<i64>,
     #[serde(rename = "e")]
     pub exchange: String,
+    #[serde(default)]
     pub listed_at: Option<i64>,
     /// "spot" | "futures"
     #[serde(rename = "m")]
@@ -211,38 +219,44 @@ pub struct CexSymbolMetadataView {
     pub quote: String,
     /// trading|pre_listing|halt|close_only|delisting|delisted
     pub status: String,
+    #[serde(default)]
     pub tags: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexSymbolOiStatsView {
     #[serde(rename = "b")]
     pub base: String,
     /// %
+    #[serde(default)]
     pub change_1h: Option<f64>,
     /// %
+    #[serde(default)]
     pub change_24h: Option<f64>,
     /// %
+    #[serde(default)]
     pub change_4h: Option<f64>,
     #[serde(rename = "e")]
     pub exchange: String,
     /// always "futures"
     #[serde(rename = "m")]
     pub market: String,
+    #[serde(default)]
     pub oi_to_vol_ratio: Option<f64>,
     pub open_interest: f64,
+    #[serde(default)]
     pub open_interest_usd: Option<f64>,
     #[serde(rename = "q")]
     pub quote: String,
+    #[serde(default)]
     pub token_id: Option<String>,
     pub ts: i64,
+    #[serde(default)]
     pub volume_24h_usd: Option<f64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexSymbolOiView {
     #[serde(rename = "b")]
@@ -253,6 +267,7 @@ pub struct CexSymbolOiView {
     #[serde(rename = "m")]
     pub market: String,
     pub open_interest: f64,
+    #[serde(default)]
     pub open_interest_usd: Option<f64>,
     #[serde(rename = "q")]
     pub quote: String,
@@ -260,7 +275,6 @@ pub struct CexSymbolOiView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexSymbolTagsView {
     #[serde(rename = "b")]
@@ -277,7 +291,6 @@ pub struct CexSymbolTagsView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexSymbolVolumeView {
     #[serde(rename = "b")]
@@ -298,11 +311,11 @@ pub struct CexSymbolVolumeView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexTokenUpdatesResponse {
     /// `data` specifies an array of the token updates
     pub data: Vec<CexTokenUpdatesView>,
+    #[serde(default)]
     pub key: Option<String>,
     pub limit: i64,
     pub page: i64,
@@ -311,7 +324,6 @@ pub struct CexTokenUpdatesResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct CexTokenUpdatesView {
     /// Specifies the base token
@@ -335,7 +347,6 @@ pub struct CexTokenUpdatesView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct ForexResponse {
     /// specifies the unix timestamp of the forex rate
@@ -350,7 +361,6 @@ pub struct ForexResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct FundingRateHistoryResponse {
     pub data: Vec<FundingRateHistoryView>,
@@ -362,19 +372,17 @@ pub struct FundingRateHistoryResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct FundingRateHistoryView {
     /// specifies the date and time in UNIX timestamp format
     #[serde(rename = "d")]
     pub timestamp: i64,
     /// specifies the funding rate
-    #[serde(rename = "f")]
+    #[serde(rename = "f", default)]
     pub funding_rate: Option<f64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct FundingRateLatestResponse {
     /// Specifies the base
@@ -387,10 +395,10 @@ pub struct FundingRateLatestResponse {
     #[serde(rename = "e")]
     pub exchange: String,
     /// Specifies the funding rate
-    #[serde(rename = "f")]
+    #[serde(rename = "f", default)]
     pub funding_rate: Option<f64>,
     /// Specifies the interval hours
-    #[serde(rename = "i")]
+    #[serde(rename = "i", default)]
     pub interval_hours: Option<i64>,
     /// Specifies the token id
     #[serde(rename = "id")]
@@ -404,7 +412,6 @@ pub struct FundingRateLatestResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct FundingRateSymbolsView {
     /// specifies the base symbol
@@ -427,14 +434,12 @@ pub struct FundingRateSymbolsView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct IndexPriceResponse {
     pub data: Vec<IndexPriceView>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct IndexPriceView {
     pub price: f64,
@@ -443,13 +448,12 @@ pub struct IndexPriceView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationEntry {
     pub base: String,
     pub exchange: String,
     pub price: f64,
-    #[serde(rename = "priceUsd")]
+    #[serde(rename = "priceUsd", default)]
     pub price_usd: Option<f64>,
     pub quote: String,
     pub side: String,
@@ -458,18 +462,17 @@ pub struct LiquidationEntry {
     #[serde(rename = "tokenId")]
     pub token_id: String,
     pub volume: f64,
-    #[serde(rename = "volumeUsd")]
+    #[serde(rename = "volumeUsd", default)]
     pub volume_usd: Option<f64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationFeedEntry {
     pub base: String,
     pub exchange: String,
     pub price: f64,
-    #[serde(rename = "priceUsd")]
+    #[serde(rename = "priceUsd", default)]
     pub price_usd: Option<f64>,
     pub quote: String,
     pub side: String,
@@ -478,19 +481,17 @@ pub struct LiquidationFeedEntry {
     #[serde(rename = "tokenId")]
     pub token_id: String,
     pub volume: f64,
-    #[serde(rename = "volumeUsd")]
+    #[serde(rename = "volumeUsd", default)]
     pub volume_usd: Option<f64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationFeedResponse {
     pub data: Vec<LiquidationFeedEntry>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationHeatmapCell {
     pub base: String,
@@ -506,7 +507,6 @@ pub struct LiquidationHeatmapCell {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationHeatmapExchangesummary {
     pub exchange: String,
@@ -519,7 +519,6 @@ pub struct LiquidationHeatmapExchangesummary {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationHeatmapResponse {
     /// (top tokens) × (all exchanges with data)
@@ -538,7 +537,6 @@ pub struct LiquidationHeatmapResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationHeatmapTokensummary {
     pub base: String,
@@ -555,7 +553,6 @@ pub struct LiquidationHeatmapTokensummary {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationMapAssumptions {
     #[serde(rename = "entrySamples")]
@@ -569,7 +566,6 @@ pub struct LiquidationMapAssumptions {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationMapBucket {
     #[serde(rename = "l100xUsd")]
@@ -587,7 +583,6 @@ pub struct LiquidationMapBucket {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationMapResponse {
     pub assumptions: LiquidationMapAssumptions,
@@ -609,7 +604,6 @@ pub struct LiquidationMapResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationMapTierassumption {
     pub leverage: i64,
@@ -617,14 +611,12 @@ pub struct LiquidationMapTierassumption {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationResponse {
     pub data: Vec<LiquidationEntry>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationStatsBiggest {
     pub base: String,
@@ -635,9 +627,9 @@ pub struct LiquidationStatsBiggest {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationStatsResponse {
+    #[serde(default)]
     pub biggest: Option<LiquidationStatsBiggest>,
     /// number of events
     pub count: i64,
@@ -662,11 +654,11 @@ pub struct LiquidationStatsResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationSymbolHistoryBucket {
     #[serde(rename = "longUsd")]
     pub long_usd: f64,
+    #[serde(default)]
     pub price: Option<f64>,
     #[serde(rename = "shortUsd")]
     pub short_usd: f64,
@@ -676,7 +668,6 @@ pub struct LiquidationSymbolHistoryBucket {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct LiquidationSymbolHistoryResponse {
     pub buckets: Vec<LiquidationSymbolHistoryBucket>,
@@ -694,27 +685,27 @@ pub struct LiquidationSymbolHistoryResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct ListingsHistoricalResponse {
     pub data: Vec<ListingsHistoricalView>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct ListingsHistoricalView {
     pub announced_at: i64,
     pub base: String,
+    #[serde(default)]
     pub deposit_at: Option<i64>,
     pub exchange: String,
+    #[serde(default)]
     pub network: Option<String>,
+    #[serde(default)]
     pub trade_at: Option<i64>,
     pub url: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct MarginBorrowResponse {
     pub cross: serde_json::Value,
@@ -722,7 +713,6 @@ pub struct MarginBorrowResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct NaverTrendView {
     #[serde(rename = "d")]
@@ -732,7 +722,6 @@ pub struct NaverTrendView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct OpenInterestHistoryAggregatedResponse {
     /// Data is keyed by exchange id → time-series points ordered by t asc.
@@ -742,14 +731,13 @@ pub struct OpenInterestHistoryAggregatedResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct OpenInterestListEntry {
     pub base: String,
     pub exchange: String,
     #[serde(rename = "openInterest")]
     pub open_interest: f64,
-    #[serde(rename = "openInterestUsd")]
+    #[serde(rename = "openInterestUsd", default)]
     pub open_interest_usd: Option<f64>,
     pub quote: String,
     pub symbol: String,
@@ -759,17 +747,16 @@ pub struct OpenInterestListEntry {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct OpenInterestListResponse {
     pub data: Vec<OpenInterestListEntry>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct OpenInterestOverviewResponse {
     pub data: Vec<OpenInterestOverviewView>,
+    #[serde(default)]
     pub key: Option<String>,
     pub limit: i64,
     pub page: i64,
@@ -778,7 +765,6 @@ pub struct OpenInterestOverviewResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct OpenInterestOverviewView {
     pub exchanges: serde_json::Value,
@@ -787,14 +773,13 @@ pub struct OpenInterestOverviewView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct OpenInterestResponse {
     pub base: String,
     pub exchange: String,
     #[serde(rename = "openInterest")]
     pub open_interest: f64,
-    #[serde(rename = "openInterestUsd")]
+    #[serde(rename = "openInterestUsd", default)]
     pub open_interest_usd: Option<f64>,
     pub quote: String,
     pub symbol: String,
@@ -804,7 +789,6 @@ pub struct OpenInterestResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct OpenInterestSummaryExchangesummary {
     pub exchange: String,
@@ -814,7 +798,6 @@ pub struct OpenInterestSummaryExchangesummary {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct OpenInterestSummaryResponse {
     pub exchanges: Vec<OpenInterestSummaryExchangesummary>,
@@ -828,7 +811,6 @@ pub struct OpenInterestSummaryResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct OpenInterestSummaryTokensummary {
     pub base: String,
@@ -843,160 +825,224 @@ pub struct OpenInterestSummaryTokensummary {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct PremiumDetail {
     pub bid: String,
     /// specifies the date and the time in UTC milliseconds
     pub d: i64,
     /// funding gap which is difference between source and target fundingrate without funding interval consideration
+    #[serde(default)]
     pub fg: Option<f64>,
     /// net fundingrate which takes funding interval into account
+    #[serde(default)]
     pub nfr: Option<f64>,
     /// specifies the price difference percentage between the source and target exchanges
+    #[serde(default)]
     pub pdp: Option<f64>,
     /// specifies the price difference percentage between the source and target exchanges 15m ago
+    #[serde(default)]
     pub pdp15m: Option<f64>,
     /// specifies the price difference percentage between the source and target exchanges 1h ago
+    #[serde(default)]
     pub pdp1h: Option<f64>,
     /// specifies the price difference percentage between the source and target exchanges 24h ago
+    #[serde(default)]
     pub pdp24h: Option<f64>,
     /// specifies the price difference percentage between the source and target exchanges 30m ago
+    #[serde(default)]
     pub pdp30m: Option<f64>,
     /// specifies the price difference percentage between the source and target exchanges 4h ago
+    #[serde(default)]
     pub pdp4h: Option<f64>,
     /// specifies the price difference percentage between the source and target exchanges 5m ago
+    #[serde(default)]
     pub pdp5m: Option<f64>,
     /// sepcifies premium duration
+    #[serde(default)]
     pub pmd: Option<i64>,
     /// source ask depth within +2% base
+    #[serde(default)]
     pub sad: Option<f64>,
     /// specifies -2% volume depth from source exchange
+    #[serde(default)]
     pub sad2p: Option<f64>,
     /// source ask depth within +2% quote
+    #[serde(default)]
     pub sadf: Option<f64>,
     /// specifies the base token of the source exchange
     pub sb: String,
     /// specifies +2% volume depth from source exchange
+    #[serde(default)]
     pub sbd2p: Option<f64>,
     /// for amm source ticker, amm source chain
+    #[serde(default)]
     pub sc: Option<String>,
     /// specifies the source exchange name
     pub se: String,
     /// source funding rate
+    #[serde(default)]
     pub sfr: Option<f64>,
     /// source funding rate interval, 1 stands for 1 hour
+    #[serde(default)]
     pub sfri: Option<i64>,
     /// source fundingrate info timestamp in UTC millisecond
+    #[serde(default)]
     pub sfrt: Option<i64>,
     /// specifies highest bid from source exchange
+    #[serde(default)]
     pub shb: Option<f64>,
     /// specifies lowest bid from source exchange
+    #[serde(default)]
     pub sla: Option<f64>,
     /// specifies the source market type
     pub sm: String,
     /// boolean if source exchange margin is supported, returned only for spot market
+    #[serde(default)]
     pub sms: Option<bool>,
     /// source next distribution time in UTC milliseconds
+    #[serde(default)]
     pub snd: Option<i64>,
     /// Open Interest snapshot — USD-denominated. Source and target sides.
+    #[serde(default)]
     pub soi: Option<f64>,
     /// OI % change over rolling 1h / 4h / 24h windows.
+    #[serde(default)]
     pub soich1h: Option<f64>,
+    #[serde(default)]
     pub soich24h: Option<f64>,
+    #[serde(default)]
     pub soich4h: Option<f64>,
     /// OI / 24h USD quote volume. Crude "leverage per turnover" metric.
+    #[serde(default)]
     pub soivr: Option<f64>,
     /// specifies the latest price of the source exchange in requested currency
+    #[serde(default)]
     pub sp: Option<f64>,
     /// for amm source ticker, amm pool address
+    #[serde(default)]
     pub spa: Option<String>,
     /// specifies the price difference percentage of the source exchange in the last 15m
+    #[serde(default)]
     pub spdp15m: Option<f64>,
     /// specifies the price difference percentage of the source exchange in the last 1h
+    #[serde(default)]
     pub spdp1h: Option<f64>,
     /// specifies the price difference percentage of the source exchange in the last 24h
+    #[serde(default)]
     pub spdp24h: Option<f64>,
     /// specifies the price difference percentage of the source exchange in the last 30m
+    #[serde(default)]
     pub spdp30m: Option<f64>,
     /// specifies the price difference percentage of the source exchange in the last 4h
+    #[serde(default)]
     pub spdp4h: Option<f64>,
     /// specifies the price difference percentage of the source exchange in the last 5m
+    #[serde(default)]
     pub spdp5m: Option<f64>,
     /// specifies the quote token of the source exchange
     pub sq: String,
     /// specifies the date and the time of source ticker in UTC milliseconds
     pub st: i64,
     /// specifies the trading volume of the source exchange in the last 24 hours in requested currency
+    #[serde(default)]
     pub sv: Option<f64>,
     /// transferable, null if unknown
+    #[serde(default)]
     pub t: Option<bool>,
     /// specifies -2% volume depth from target exchange
+    #[serde(default)]
     pub tad2p: Option<f64>,
     /// specifies the base token of the target exchange
     pub tb: String,
     /// target bid depth within -2% base
+    #[serde(default)]
     pub tbd: Option<f64>,
     /// specifies +2% volume depth from target exchange
+    #[serde(default)]
     pub tbd2p: Option<f64>,
     /// target bid depth within -2% quote
+    #[serde(default)]
     pub tbdf: Option<f64>,
     /// for amm target ticker, amm target chain
+    #[serde(default)]
     pub tc: Option<String>,
     /// specifies the target exchange name
     pub te: String,
     /// target funding rate
+    #[serde(default)]
     pub tfr: Option<f64>,
     /// target funding rate interval, 1 stands for 1 hour
+    #[serde(default)]
     pub tfri: Option<i64>,
     /// target fundingrate info timestamp in UTC millisecond
+    #[serde(default)]
     pub tfrt: Option<i64>,
     /// specifies highest bid from target exchange
+    #[serde(default)]
     pub thb: Option<f64>,
     /// specifies lowest bid from target exchange
+    #[serde(default)]
     pub tla: Option<f64>,
     /// specifies the target market type
     pub tm: String,
     /// boolean if target exchange margin is supported, returned only for spot market
+    #[serde(default)]
     pub tms: Option<bool>,
     /// target next distribution time in UTC millisconds
+    #[serde(default)]
     pub tnd: Option<i64>,
+    #[serde(default)]
     pub toi: Option<f64>,
+    #[serde(default)]
     pub toich1h: Option<f64>,
+    #[serde(default)]
     pub toich24h: Option<f64>,
+    #[serde(default)]
     pub toich4h: Option<f64>,
+    #[serde(default)]
     pub toivr: Option<f64>,
     /// specifies the latest price of the target exchange
+    #[serde(default)]
     pub tp: Option<f64>,
     /// for amm target ticker, amm pool address
+    #[serde(default)]
     pub tpa: Option<String>,
     /// specifies the price difference percentage of the target exchange in the last 15m
+    #[serde(default)]
     pub tpdp15m: Option<f64>,
     /// specifies the price difference percentage of the target exchange in the last 1h
+    #[serde(default)]
     pub tpdp1h: Option<f64>,
     /// specifies the price difference percentage of the target exchange in the last 24h
+    #[serde(default)]
     pub tpdp24h: Option<f64>,
     /// specifies the price difference percentage of the target exchange in the last 30m
+    #[serde(default)]
     pub tpdp30m: Option<f64>,
     /// specifies the price difference percentage of the target exchange in the last 4h
+    #[serde(default)]
     pub tpdp4h: Option<f64>,
     /// specifies the price difference percentage of the target exchange in the last 5m
+    #[serde(default)]
     pub tpdp5m: Option<f64>,
     /// specifies the quote token of the target exchange
     pub tq: String,
     /// specifies the date and the time of target ticker in UTC milliseconds
     pub tt: i64,
     /// specifies the trading volume of the target exchange in the last 24 hours in requested currency
+    #[serde(default)]
     pub tv: Option<f64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct PremiumResponse {
+    #[serde(default)]
     pub conversion_base: Option<String>,
+    #[serde(default)]
     pub currency: Option<String>,
     pub data: Vec<PremiumView>,
+    #[serde(default)]
     pub key: Option<String>,
     pub limit: i64,
     pub page: i64,
@@ -1005,20 +1051,22 @@ pub struct PremiumResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct PremiumView {
     pub detail: PremiumDetail,
+    #[serde(default)]
     pub source_annualized_funding_rate: Option<f64>,
+    #[serde(default)]
     pub target_annualized_funding_rate: Option<f64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct TelegramChannelsResponse {
+    #[serde(default)]
     pub category: Option<String>,
     pub data: Vec<TelegramChannelsView>,
+    #[serde(default)]
     pub key: Option<String>,
     pub limit: i64,
     pub page: i64,
@@ -1027,7 +1075,6 @@ pub struct TelegramChannelsResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct TelegramChannelsView {
     /// specifies the channel category
@@ -1039,7 +1086,7 @@ pub struct TelegramChannelsView {
     #[serde(rename = "channelTitle")]
     pub channel_title: String,
     /// specifies the creation time of the channel
-    #[serde(rename = "createdAt")]
+    #[serde(rename = "createdAt", default)]
     pub created_at: Option<i64>,
     /// specifies the channel description
     pub description: String,
@@ -1050,12 +1097,13 @@ pub struct TelegramChannelsView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct TelegramMessagesResponse {
+    #[serde(default)]
     pub category: Option<String>,
     /// specifies an array of the Telegram messages
     pub data: Vec<TelegramMessagesView>,
+    #[serde(default)]
     pub key: Option<String>,
     pub limit: i64,
     pub page: i64,
@@ -1064,7 +1112,6 @@ pub struct TelegramMessagesResponse {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct TelegramMessagesView {
     /// specifies the channel handle
@@ -1096,18 +1143,17 @@ pub struct TelegramMessagesView {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct TickerResponse {
     pub currency: String,
     pub data: TickerView,
     pub market: String,
     /// Source is populated only when ?include_source=true; omitempty drops the key for default callers, preserving the pre-Phase-1 JSON byte shape (strict-decoder safe).
+    #[serde(default)]
     pub src: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct TickerView {
     /// specifies the base token
@@ -1120,25 +1166,25 @@ pub struct TickerView {
     #[serde(rename = "e")]
     pub exchange: String,
     /// highest bid from orderbook
-    #[serde(rename = "hb")]
+    #[serde(rename = "hb", default)]
     pub highest_bid: Option<f64>,
     /// lowest ask from orderbook
-    #[serde(rename = "la")]
+    #[serde(rename = "la", default)]
     pub lowest_ask: Option<f64>,
     /// lower depth(2%)
-    #[serde(rename = "ld")]
+    #[serde(rename = "ld", default)]
     pub lower_depth: Option<f64>,
     /// specifies the market type
     #[serde(rename = "m")]
     pub market: String,
     /// specifies the latest price
-    #[serde(rename = "p")]
+    #[serde(rename = "p", default)]
     pub price: Option<f64>,
     /// specifies the price 24 hours ago
-    #[serde(rename = "p24h")]
+    #[serde(rename = "p24h", default)]
     pub price_24h: Option<f64>,
     /// specified price change between the latest price and the price 24 hours ago
-    #[serde(rename = "pc")]
+    #[serde(rename = "pc", default)]
     pub price_change: Option<f64>,
     /// specifies the quote token
     #[serde(rename = "q")]
@@ -1147,18 +1193,18 @@ pub struct TickerView {
     #[serde(rename = "s")]
     pub symbol: String,
     /// upper depth(2%)
-    #[serde(rename = "ud")]
+    #[serde(rename = "ud", default)]
     pub upper_depth: Option<f64>,
     /// specifies the trading volume in the last 24 hours
-    #[serde(rename = "v")]
+    #[serde(rename = "v", default)]
     pub volume: Option<f64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct TokenDetail {
     /// specifies cmc id of the token
+    #[serde(default)]
     pub cmc_id: Option<String>,
     /// specifies the token icon url path
     pub icon: String,
@@ -1171,7 +1217,6 @@ pub struct TokenDetail {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
 #[non_exhaustive]
 pub struct WalletStatusView {
     pub currency: String,

--- a/tests/generated_contract.rs
+++ b/tests/generated_contract.rs
@@ -20,6 +20,24 @@ where
     assert_eq!(reserialized, fixture);
 }
 
+/// Assert a payload MISSING `required_key` fails to deserialize into `T`.
+/// A required field carries no serde default, so its absence must be a hard
+/// decode error rather than a silently-defaulted zero value (issue #86).
+fn assert_missing_required<T: serde::de::DeserializeOwned>(
+    mut fixture: serde_json::Value,
+    required_key: &str,
+) {
+    fixture
+        .as_object_mut()
+        .expect("fixture is a JSON object")
+        .remove(required_key)
+        .expect("required_key is present in the fixture");
+    assert!(
+        serde_json::from_value::<T>(fixture).is_err(),
+        "missing required field `{required_key}` must fail to deserialize",
+    );
+}
+
 #[test]
 fn contract_cex_announcements_response() {
     let fixture = serde_json::json!({
@@ -49,6 +67,34 @@ fn contract_cex_announcements_response() {
 }
 
 #[test]
+fn contract_cex_announcements_response_missing_required() {
+    let fixture = serde_json::json!({
+        "category": [
+            "s",
+        ],
+        "data": [
+            {
+                "c": "s",
+                "d": 1,
+                "e": "s",
+                "s": "s",
+                "t": "s",
+                "u": "s",
+            },
+        ],
+        "exchange": [
+            "s",
+        ],
+        "key": "s",
+        "limit": 1,
+        "page": 1,
+        "sort": "s",
+        "total": 1,
+    });
+    assert_missing_required::<datamaxi::CexAnnouncementsResponse>(fixture, "data");
+}
+
+#[test]
 fn contract_cex_announcements_view() {
     let fixture = serde_json::json!({
         "c": "s",
@@ -59,6 +105,19 @@ fn contract_cex_announcements_view() {
         "u": "s",
     });
     assert_roundtrip::<datamaxi::CexAnnouncementsView>(fixture);
+}
+
+#[test]
+fn contract_cex_announcements_view_missing_required() {
+    let fixture = serde_json::json!({
+        "c": "s",
+        "d": 1,
+        "e": "s",
+        "s": "s",
+        "t": "s",
+        "u": "s",
+    });
+    assert_missing_required::<datamaxi::CexAnnouncementsView>(fixture, "c");
 }
 
 #[test]
@@ -84,6 +143,28 @@ fn contract_cex_candle_response() {
 }
 
 #[test]
+fn contract_cex_candle_response_missing_required() {
+    let fixture = serde_json::json!({
+        "currency": "s",
+        "data": [
+            {
+                "c": 1.5,
+                "d": 1,
+                "h": 1.5,
+                "l": 1.5,
+                "o": 1.5,
+                "v": 1.5,
+            },
+        ],
+        "exchange": "s",
+        "interval": "s",
+        "market": "s",
+        "symbol": "s",
+    });
+    assert_missing_required::<datamaxi::CexCandleResponse>(fixture, "currency");
+}
+
+#[test]
 fn contract_cex_candle_symbols_view() {
     let fixture = serde_json::json!({
         "b": "s",
@@ -94,6 +175,19 @@ fn contract_cex_candle_symbols_view() {
         "s": "s",
     });
     assert_roundtrip::<datamaxi::CexCandleSymbolsView>(fixture);
+}
+
+#[test]
+fn contract_cex_candle_symbols_view_missing_required() {
+    let fixture = serde_json::json!({
+        "b": "s",
+        "e": "s",
+        "id": "s",
+        "m": "s",
+        "q": "s",
+        "s": "s",
+    });
+    assert_missing_required::<datamaxi::CexCandleSymbolsView>(fixture, "b");
 }
 
 #[test]
@@ -110,6 +204,19 @@ fn contract_cex_candle_view() {
 }
 
 #[test]
+fn contract_cex_candle_view_missing_required() {
+    let fixture = serde_json::json!({
+        "c": 1.5,
+        "d": 1,
+        "h": 1.5,
+        "l": 1.5,
+        "o": 1.5,
+        "v": 1.5,
+    });
+    assert_missing_required::<datamaxi::CexCandleView>(fixture, "c");
+}
+
+#[test]
 fn contract_cex_fees_view() {
     let fixture = serde_json::json!({
         "base": "s",
@@ -122,6 +229,21 @@ fn contract_cex_fees_view() {
         "symbol": "s",
     });
     assert_roundtrip::<datamaxi::CexFeesView>(fixture);
+}
+
+#[test]
+fn contract_cex_fees_view_missing_required() {
+    let fixture = serde_json::json!({
+        "base": "s",
+        "exchange": "s",
+        "futures_maker_fee": 1.5,
+        "futures_taker_fee": 1.5,
+        "quote": "s",
+        "spot_maker_fee": 1.5,
+        "spot_take_fee": 1.5,
+        "symbol": "s",
+    });
+    assert_missing_required::<datamaxi::CexFeesView>(fixture, "base");
 }
 
 #[test]
@@ -141,6 +263,22 @@ fn contract_cex_symbol_cautions_view() {
 }
 
 #[test]
+fn contract_cex_symbol_cautions_view_missing_required() {
+    let fixture = serde_json::json!({
+        "b": "s",
+        "caution_level": "s",
+        "e": "s",
+        "end_at": 1,
+        "m": "s",
+        "q": "s",
+        "reasons": [
+            "s",
+        ],
+    });
+    assert_missing_required::<datamaxi::CexSymbolCautionsView>(fixture, "b");
+}
+
+#[test]
 fn contract_cex_symbol_delistings_view() {
     let fixture = serde_json::json!({
         "b": "s",
@@ -152,6 +290,20 @@ fn contract_cex_symbol_delistings_view() {
         "status": "s",
     });
     assert_roundtrip::<datamaxi::CexSymbolDelistingsView>(fixture);
+}
+
+#[test]
+fn contract_cex_symbol_delistings_view_missing_required() {
+    let fixture = serde_json::json!({
+        "b": "s",
+        "delisting_at": 1,
+        "e": "s",
+        "listed_at": 1,
+        "m": "s",
+        "q": "s",
+        "status": "s",
+    });
+    assert_missing_required::<datamaxi::CexSymbolDelistingsView>(fixture, "b");
 }
 
 #[test]
@@ -170,6 +322,24 @@ fn contract_cex_symbol_liquidation_view() {
         "total_volume_usd": 1.5,
     });
     assert_roundtrip::<datamaxi::CexSymbolLiquidationView>(fixture);
+}
+
+#[test]
+fn contract_cex_symbol_liquidation_view_missing_required() {
+    let fixture = serde_json::json!({
+        "b": "s",
+        "e": "s",
+        "event_count": 1,
+        "long_volume": 1.5,
+        "long_volume_usd": 1.5,
+        "m": "s",
+        "q": "s",
+        "short_volume": 1.5,
+        "short_volume_usd": 1.5,
+        "total_volume": 1.5,
+        "total_volume_usd": 1.5,
+    });
+    assert_missing_required::<datamaxi::CexSymbolLiquidationView>(fixture, "b");
 }
 
 #[test]
@@ -195,6 +365,28 @@ fn contract_cex_symbol_metadata_view() {
 }
 
 #[test]
+fn contract_cex_symbol_metadata_view_missing_required() {
+    let fixture = serde_json::json!({
+        "b": "s",
+        "caution_end_at": 1,
+        "caution_level": "s",
+        "caution_reasons": [
+            "s",
+        ],
+        "delisting_at": 1,
+        "e": "s",
+        "listed_at": 1,
+        "m": "s",
+        "q": "s",
+        "status": "s",
+        "tags": [
+            "s",
+        ],
+    });
+    assert_missing_required::<datamaxi::CexSymbolMetadataView>(fixture, "b");
+}
+
+#[test]
 fn contract_cex_symbol_oi_stats_view() {
     let fixture = serde_json::json!({
         "b": "s",
@@ -215,6 +407,26 @@ fn contract_cex_symbol_oi_stats_view() {
 }
 
 #[test]
+fn contract_cex_symbol_oi_stats_view_missing_required() {
+    let fixture = serde_json::json!({
+        "b": "s",
+        "change_1h": 1.5,
+        "change_24h": 1.5,
+        "change_4h": 1.5,
+        "e": "s",
+        "m": "s",
+        "oi_to_vol_ratio": 1.5,
+        "open_interest": 1.5,
+        "open_interest_usd": 1.5,
+        "q": "s",
+        "token_id": "s",
+        "ts": 1,
+        "volume_24h_usd": 1.5,
+    });
+    assert_missing_required::<datamaxi::CexSymbolOiStatsView>(fixture, "b");
+}
+
+#[test]
 fn contract_cex_symbol_oi_view() {
     let fixture = serde_json::json!({
         "b": "s",
@@ -226,6 +438,20 @@ fn contract_cex_symbol_oi_view() {
         "ts": 1,
     });
     assert_roundtrip::<datamaxi::CexSymbolOiView>(fixture);
+}
+
+#[test]
+fn contract_cex_symbol_oi_view_missing_required() {
+    let fixture = serde_json::json!({
+        "b": "s",
+        "e": "s",
+        "m": "s",
+        "open_interest": 1.5,
+        "open_interest_usd": 1.5,
+        "q": "s",
+        "ts": 1,
+    });
+    assert_missing_required::<datamaxi::CexSymbolOiView>(fixture, "b");
 }
 
 #[test]
@@ -243,6 +469,20 @@ fn contract_cex_symbol_tags_view() {
 }
 
 #[test]
+fn contract_cex_symbol_tags_view_missing_required() {
+    let fixture = serde_json::json!({
+        "b": "s",
+        "confidence": 1,
+        "e": "s",
+        "m": "s",
+        "q": "s",
+        "source": "s",
+        "tag": "s",
+    });
+    assert_missing_required::<datamaxi::CexSymbolTagsView>(fixture, "b");
+}
+
+#[test]
 fn contract_cex_symbol_volume_view() {
     let fixture = serde_json::json!({
         "b": "s",
@@ -254,6 +494,20 @@ fn contract_cex_symbol_volume_view() {
         "volume": 1.5,
     });
     assert_roundtrip::<datamaxi::CexSymbolVolumeView>(fixture);
+}
+
+#[test]
+fn contract_cex_symbol_volume_view_missing_required() {
+    let fixture = serde_json::json!({
+        "b": "s",
+        "e": "s",
+        "m": "s",
+        "q": "s",
+        "quote_volume": 1.5,
+        "ts": 1,
+        "volume": 1.5,
+    });
+    assert_missing_required::<datamaxi::CexSymbolVolumeView>(fixture, "b");
 }
 
 #[test]
@@ -279,6 +533,28 @@ fn contract_cex_token_updates_response() {
 }
 
 #[test]
+fn contract_cex_token_updates_response_missing_required() {
+    let fixture = serde_json::json!({
+        "data": [
+            {
+                "b": "s",
+                "d": 1,
+                "e": "s",
+                "m": "s",
+                "q": "s",
+                "t": "s",
+            },
+        ],
+        "key": "s",
+        "limit": 1,
+        "page": 1,
+        "sort": "s",
+        "total": 1,
+    });
+    assert_missing_required::<datamaxi::CexTokenUpdatesResponse>(fixture, "data");
+}
+
+#[test]
 fn contract_cex_token_updates_view() {
     let fixture = serde_json::json!({
         "b": "s",
@@ -292,6 +568,19 @@ fn contract_cex_token_updates_view() {
 }
 
 #[test]
+fn contract_cex_token_updates_view_missing_required() {
+    let fixture = serde_json::json!({
+        "b": "s",
+        "d": 1,
+        "e": "s",
+        "m": "s",
+        "q": "s",
+        "t": "s",
+    });
+    assert_missing_required::<datamaxi::CexTokenUpdatesView>(fixture, "b");
+}
+
+#[test]
 fn contract_forex_response() {
     let fixture = serde_json::json!({
         "d": 1,
@@ -299,6 +588,16 @@ fn contract_forex_response() {
         "s": "s",
     });
     assert_roundtrip::<datamaxi::ForexResponse>(fixture);
+}
+
+#[test]
+fn contract_forex_response_missing_required() {
+    let fixture = serde_json::json!({
+        "d": 1,
+        "r": 1.5,
+        "s": "s",
+    });
+    assert_missing_required::<datamaxi::ForexResponse>(fixture, "d");
 }
 
 #[test]
@@ -320,12 +619,39 @@ fn contract_funding_rate_history_response() {
 }
 
 #[test]
+fn contract_funding_rate_history_response_missing_required() {
+    let fixture = serde_json::json!({
+        "data": [
+            {
+                "d": 1,
+                "f": 1.5,
+            },
+        ],
+        "exchange": "s",
+        "limit": 1,
+        "page": 1,
+        "sort": "s",
+        "symbol": "s",
+    });
+    assert_missing_required::<datamaxi::FundingRateHistoryResponse>(fixture, "data");
+}
+
+#[test]
 fn contract_funding_rate_history_view() {
     let fixture = serde_json::json!({
         "d": 1,
         "f": 1.5,
     });
     assert_roundtrip::<datamaxi::FundingRateHistoryView>(fixture);
+}
+
+#[test]
+fn contract_funding_rate_history_view_missing_required() {
+    let fixture = serde_json::json!({
+        "d": 1,
+        "f": 1.5,
+    });
+    assert_missing_required::<datamaxi::FundingRateHistoryView>(fixture, "d");
 }
 
 #[test]
@@ -344,6 +670,21 @@ fn contract_funding_rate_latest_response() {
 }
 
 #[test]
+fn contract_funding_rate_latest_response_missing_required() {
+    let fixture = serde_json::json!({
+        "b": "s",
+        "d": 1,
+        "e": "s",
+        "f": 1.5,
+        "i": 1,
+        "id": "s",
+        "q": "s",
+        "s": "s",
+    });
+    assert_missing_required::<datamaxi::FundingRateLatestResponse>(fixture, "b");
+}
+
+#[test]
 fn contract_funding_rate_symbols_view() {
     let fixture = serde_json::json!({
         "b": "s",
@@ -354,6 +695,19 @@ fn contract_funding_rate_symbols_view() {
         "s": "s",
     });
     assert_roundtrip::<datamaxi::FundingRateSymbolsView>(fixture);
+}
+
+#[test]
+fn contract_funding_rate_symbols_view_missing_required() {
+    let fixture = serde_json::json!({
+        "b": "s",
+        "e": "s",
+        "id": "s",
+        "m": "s",
+        "q": "s",
+        "s": "s",
+    });
+    assert_missing_required::<datamaxi::FundingRateSymbolsView>(fixture, "b");
 }
 
 #[test]
@@ -371,6 +725,20 @@ fn contract_index_price_response() {
 }
 
 #[test]
+fn contract_index_price_response_missing_required() {
+    let fixture = serde_json::json!({
+        "data": [
+            {
+                "price": 1.5,
+                "timestamp": 1,
+                "volume": 1.5,
+            },
+        ],
+    });
+    assert_missing_required::<datamaxi::IndexPriceResponse>(fixture, "data");
+}
+
+#[test]
 fn contract_index_price_view() {
     let fixture = serde_json::json!({
         "price": 1.5,
@@ -378,6 +746,16 @@ fn contract_index_price_view() {
         "volume": 1.5,
     });
     assert_roundtrip::<datamaxi::IndexPriceView>(fixture);
+}
+
+#[test]
+fn contract_index_price_view_missing_required() {
+    let fixture = serde_json::json!({
+        "price": 1.5,
+        "timestamp": 1,
+        "volume": 1.5,
+    });
+    assert_missing_required::<datamaxi::IndexPriceView>(fixture, "price");
 }
 
 #[test]
@@ -399,6 +777,24 @@ fn contract_liquidation_entry() {
 }
 
 #[test]
+fn contract_liquidation_entry_missing_required() {
+    let fixture = serde_json::json!({
+        "base": "s",
+        "exchange": "s",
+        "price": 1.5,
+        "priceUsd": 1.5,
+        "quote": "s",
+        "side": "s",
+        "symbol": "s",
+        "timestamp": 1,
+        "tokenId": "s",
+        "volume": 1.5,
+        "volumeUsd": 1.5,
+    });
+    assert_missing_required::<datamaxi::LiquidationEntry>(fixture, "base");
+}
+
+#[test]
 fn contract_liquidation_feed_entry() {
     let fixture = serde_json::json!({
         "base": "s",
@@ -414,6 +810,24 @@ fn contract_liquidation_feed_entry() {
         "volumeUsd": 1.5,
     });
     assert_roundtrip::<datamaxi::LiquidationFeedEntry>(fixture);
+}
+
+#[test]
+fn contract_liquidation_feed_entry_missing_required() {
+    let fixture = serde_json::json!({
+        "base": "s",
+        "exchange": "s",
+        "price": 1.5,
+        "priceUsd": 1.5,
+        "quote": "s",
+        "side": "s",
+        "symbol": "s",
+        "timestamp": 1,
+        "tokenId": "s",
+        "volume": 1.5,
+        "volumeUsd": 1.5,
+    });
+    assert_missing_required::<datamaxi::LiquidationFeedEntry>(fixture, "base");
 }
 
 #[test]
@@ -439,6 +853,28 @@ fn contract_liquidation_feed_response() {
 }
 
 #[test]
+fn contract_liquidation_feed_response_missing_required() {
+    let fixture = serde_json::json!({
+        "data": [
+            {
+                "base": "s",
+                "exchange": "s",
+                "price": 1.5,
+                "priceUsd": 1.5,
+                "quote": "s",
+                "side": "s",
+                "symbol": "s",
+                "timestamp": 1,
+                "tokenId": "s",
+                "volume": 1.5,
+                "volumeUsd": 1.5,
+            },
+        ],
+    });
+    assert_missing_required::<datamaxi::LiquidationFeedResponse>(fixture, "data");
+}
+
+#[test]
 fn contract_liquidation_heatmap_cell() {
     let fixture = serde_json::json!({
         "base": "s",
@@ -452,6 +888,19 @@ fn contract_liquidation_heatmap_cell() {
 }
 
 #[test]
+fn contract_liquidation_heatmap_cell_missing_required() {
+    let fixture = serde_json::json!({
+        "base": "s",
+        "exchange": "s",
+        "longUsd": 1.5,
+        "shortUsd": 1.5,
+        "tokenId": "s",
+        "totalUsd": 1.5,
+    });
+    assert_missing_required::<datamaxi::LiquidationHeatmapCell>(fixture, "base");
+}
+
+#[test]
 fn contract_liquidation_heatmap_exchangesummary() {
     let fixture = serde_json::json!({
         "exchange": "s",
@@ -460,6 +909,17 @@ fn contract_liquidation_heatmap_exchangesummary() {
         "totalUsd": 1.5,
     });
     assert_roundtrip::<datamaxi::LiquidationHeatmapExchangesummary>(fixture);
+}
+
+#[test]
+fn contract_liquidation_heatmap_exchangesummary_missing_required() {
+    let fixture = serde_json::json!({
+        "exchange": "s",
+        "longUsd": 1.5,
+        "shortUsd": 1.5,
+        "totalUsd": 1.5,
+    });
+    assert_missing_required::<datamaxi::LiquidationHeatmapExchangesummary>(fixture, "exchange");
 }
 
 #[test]
@@ -502,6 +962,45 @@ fn contract_liquidation_heatmap_response() {
 }
 
 #[test]
+fn contract_liquidation_heatmap_response_missing_required() {
+    let fixture = serde_json::json!({
+        "cells": [
+            {
+                "base": "s",
+                "exchange": "s",
+                "longUsd": 1.5,
+                "shortUsd": 1.5,
+                "tokenId": "s",
+                "totalUsd": 1.5,
+            },
+        ],
+        "exchanges": [
+            {
+                "exchange": "s",
+                "longUsd": 1.5,
+                "shortUsd": 1.5,
+                "totalUsd": 1.5,
+            },
+        ],
+        "generatedAt": 1,
+        "grandTotal": 1.5,
+        "tokens": [
+            {
+                "base": "s",
+                "longUsd": 1.5,
+                "name": "s",
+                "shortUsd": 1.5,
+                "symbol": "s",
+                "tokenId": "s",
+                "totalUsd": 1.5,
+            },
+        ],
+        "window": "s",
+    });
+    assert_missing_required::<datamaxi::LiquidationHeatmapResponse>(fixture, "cells");
+}
+
+#[test]
 fn contract_liquidation_heatmap_tokensummary() {
     let fixture = serde_json::json!({
         "base": "s",
@@ -513,6 +1012,20 @@ fn contract_liquidation_heatmap_tokensummary() {
         "totalUsd": 1.5,
     });
     assert_roundtrip::<datamaxi::LiquidationHeatmapTokensummary>(fixture);
+}
+
+#[test]
+fn contract_liquidation_heatmap_tokensummary_missing_required() {
+    let fixture = serde_json::json!({
+        "base": "s",
+        "longUsd": 1.5,
+        "name": "s",
+        "shortUsd": 1.5,
+        "symbol": "s",
+        "tokenId": "s",
+        "totalUsd": 1.5,
+    });
+    assert_missing_required::<datamaxi::LiquidationHeatmapTokensummary>(fixture, "base");
 }
 
 #[test]
@@ -533,6 +1046,23 @@ fn contract_liquidation_map_assumptions() {
 }
 
 #[test]
+fn contract_liquidation_map_assumptions_missing_required() {
+    let fixture = serde_json::json!({
+        "entrySamples": 1,
+        "entryWindow": "s",
+        "longShareOfOi": 1.5,
+        "mmr": 1.5,
+        "tiers": [
+            {
+                "leverage": 1,
+                "share": 1.5,
+            },
+        ],
+    });
+    assert_missing_required::<datamaxi::LiquidationMapAssumptions>(fixture, "entrySamples");
+}
+
+#[test]
 fn contract_liquidation_map_bucket() {
     let fixture = serde_json::json!({
         "l100xUsd": 1.5,
@@ -544,6 +1074,20 @@ fn contract_liquidation_map_bucket() {
         "totalUsd": 1.5,
     });
     assert_roundtrip::<datamaxi::LiquidationMapBucket>(fixture);
+}
+
+#[test]
+fn contract_liquidation_map_bucket_missing_required() {
+    let fixture = serde_json::json!({
+        "l100xUsd": 1.5,
+        "l10xUsd": 1.5,
+        "l25xUsd": 1.5,
+        "l50xUsd": 1.5,
+        "price": 1.5,
+        "side": "s",
+        "totalUsd": 1.5,
+    });
+    assert_missing_required::<datamaxi::LiquidationMapBucket>(fixture, "l100xUsd");
 }
 
 #[test]
@@ -586,12 +1130,60 @@ fn contract_liquidation_map_response() {
 }
 
 #[test]
+fn contract_liquidation_map_response_missing_required() {
+    let fixture = serde_json::json!({
+        "assumptions": {
+            "entrySamples": 1,
+            "entryWindow": "s",
+            "longShareOfOi": 1.5,
+            "mmr": 1.5,
+            "tiers": [
+                {
+                    "leverage": 1,
+                    "share": 1.5,
+                },
+            ],
+        },
+        "base": "s",
+        "buckets": [
+            {
+                "l100xUsd": 1.5,
+                "l10xUsd": 1.5,
+                "l25xUsd": 1.5,
+                "l50xUsd": 1.5,
+                "price": 1.5,
+                "side": "s",
+                "totalUsd": 1.5,
+            },
+        ],
+        "cumulativeLongUsd": 1.5,
+        "cumulativeShortUsd": 1.5,
+        "currentPrice": 1.5,
+        "exchange": "s",
+        "generatedAt": 1,
+        "quote": "s",
+        "symbol": "s",
+        "totalOiUsd": 1.5,
+    });
+    assert_missing_required::<datamaxi::LiquidationMapResponse>(fixture, "assumptions");
+}
+
+#[test]
 fn contract_liquidation_map_tierassumption() {
     let fixture = serde_json::json!({
         "leverage": 1,
         "share": 1.5,
     });
     assert_roundtrip::<datamaxi::LiquidationMapTierassumption>(fixture);
+}
+
+#[test]
+fn contract_liquidation_map_tierassumption_missing_required() {
+    let fixture = serde_json::json!({
+        "leverage": 1,
+        "share": 1.5,
+    });
+    assert_missing_required::<datamaxi::LiquidationMapTierassumption>(fixture, "leverage");
 }
 
 #[test]
@@ -617,6 +1209,28 @@ fn contract_liquidation_response() {
 }
 
 #[test]
+fn contract_liquidation_response_missing_required() {
+    let fixture = serde_json::json!({
+        "data": [
+            {
+                "base": "s",
+                "exchange": "s",
+                "price": 1.5,
+                "priceUsd": 1.5,
+                "quote": "s",
+                "side": "s",
+                "symbol": "s",
+                "timestamp": 1,
+                "tokenId": "s",
+                "volume": 1.5,
+                "volumeUsd": 1.5,
+            },
+        ],
+    });
+    assert_missing_required::<datamaxi::LiquidationResponse>(fixture, "data");
+}
+
+#[test]
 fn contract_liquidation_stats_biggest() {
     let fixture = serde_json::json!({
         "base": "s",
@@ -625,6 +1239,17 @@ fn contract_liquidation_stats_biggest() {
         "volumeUsd": 1.5,
     });
     assert_roundtrip::<datamaxi::LiquidationStatsBiggest>(fixture);
+}
+
+#[test]
+fn contract_liquidation_stats_biggest_missing_required() {
+    let fixture = serde_json::json!({
+        "base": "s",
+        "exchange": "s",
+        "quote": "s",
+        "volumeUsd": 1.5,
+    });
+    assert_missing_required::<datamaxi::LiquidationStatsBiggest>(fixture, "base");
 }
 
 #[test]
@@ -649,6 +1274,27 @@ fn contract_liquidation_stats_response() {
 }
 
 #[test]
+fn contract_liquidation_stats_response_missing_required() {
+    let fixture = serde_json::json!({
+        "biggest": {
+            "base": "s",
+            "exchange": "s",
+            "quote": "s",
+            "volumeUsd": 1.5,
+        },
+        "count": 1,
+        "generatedAt": 1,
+        "longRatio": 1,
+        "longUsd": 1.5,
+        "shortUsd": 1.5,
+        "total": 1.5,
+        "venues": 1,
+        "window": "s",
+    });
+    assert_missing_required::<datamaxi::LiquidationStatsResponse>(fixture, "count");
+}
+
+#[test]
 fn contract_liquidation_symbol_history_bucket() {
     let fixture = serde_json::json!({
         "longUsd": 1.5,
@@ -658,6 +1304,18 @@ fn contract_liquidation_symbol_history_bucket() {
         "ts": 1,
     });
     assert_roundtrip::<datamaxi::LiquidationSymbolHistoryBucket>(fixture);
+}
+
+#[test]
+fn contract_liquidation_symbol_history_bucket_missing_required() {
+    let fixture = serde_json::json!({
+        "longUsd": 1.5,
+        "price": 1.5,
+        "shortUsd": 1.5,
+        "totalUsd": 1.5,
+        "ts": 1,
+    });
+    assert_missing_required::<datamaxi::LiquidationSymbolHistoryBucket>(fixture, "longUsd");
 }
 
 #[test]
@@ -685,6 +1343,30 @@ fn contract_liquidation_symbol_history_response() {
 }
 
 #[test]
+fn contract_liquidation_symbol_history_response_missing_required() {
+    let fixture = serde_json::json!({
+        "buckets": [
+            {
+                "longUsd": 1.5,
+                "price": 1.5,
+                "shortUsd": 1.5,
+                "totalUsd": 1.5,
+                "ts": 1,
+            },
+        ],
+        "exchange": "s",
+        "generatedAt": 1,
+        "interval": "s",
+        "quote": "s",
+        "symbol": "s",
+        "totalLongUsd": 1.5,
+        "totalShortUsd": 1.5,
+        "window": "s",
+    });
+    assert_missing_required::<datamaxi::LiquidationSymbolHistoryResponse>(fixture, "buckets");
+}
+
+#[test]
 fn contract_listings_historical_response() {
     let fixture = serde_json::json!({
         "data": [
@@ -703,6 +1385,24 @@ fn contract_listings_historical_response() {
 }
 
 #[test]
+fn contract_listings_historical_response_missing_required() {
+    let fixture = serde_json::json!({
+        "data": [
+            {
+                "announced_at": 1,
+                "base": "s",
+                "deposit_at": 1,
+                "exchange": "s",
+                "network": "s",
+                "trade_at": 1,
+                "url": "s",
+            },
+        ],
+    });
+    assert_missing_required::<datamaxi::ListingsHistoricalResponse>(fixture, "data");
+}
+
+#[test]
 fn contract_listings_historical_view() {
     let fixture = serde_json::json!({
         "announced_at": 1,
@@ -717,6 +1417,20 @@ fn contract_listings_historical_view() {
 }
 
 #[test]
+fn contract_listings_historical_view_missing_required() {
+    let fixture = serde_json::json!({
+        "announced_at": 1,
+        "base": "s",
+        "deposit_at": 1,
+        "exchange": "s",
+        "network": "s",
+        "trade_at": 1,
+        "url": "s",
+    });
+    assert_missing_required::<datamaxi::ListingsHistoricalView>(fixture, "announced_at");
+}
+
+#[test]
 fn contract_margin_borrow_response() {
     let fixture = serde_json::json!({
         "cross": "s",
@@ -726,12 +1440,30 @@ fn contract_margin_borrow_response() {
 }
 
 #[test]
+fn contract_margin_borrow_response_missing_required() {
+    let fixture = serde_json::json!({
+        "cross": "s",
+        "isolated": "s",
+    });
+    assert_missing_required::<datamaxi::MarginBorrowResponse>(fixture, "cross");
+}
+
+#[test]
 fn contract_naver_trend_view() {
     let fixture = serde_json::json!({
         "d": 1,
         "v": 1.5,
     });
     assert_roundtrip::<datamaxi::NaverTrendView>(fixture);
+}
+
+#[test]
+fn contract_naver_trend_view_missing_required() {
+    let fixture = serde_json::json!({
+        "d": 1,
+        "v": 1.5,
+    });
+    assert_missing_required::<datamaxi::NaverTrendView>(fixture, "d");
 }
 
 #[test]
@@ -751,6 +1483,22 @@ fn contract_open_interest_history_aggregated_response() {
 }
 
 #[test]
+fn contract_open_interest_history_aggregated_response_missing_required() {
+    let fixture = serde_json::json!({
+        "data": "s",
+        "exchange_url": "s",
+        "token": {
+            "cmc_id": "s",
+            "icon": "s",
+            "id": "s",
+            "name": "s",
+            "symbol": "s",
+        },
+    });
+    assert_missing_required::<datamaxi::OpenInterestHistoryAggregatedResponse>(fixture, "data");
+}
+
+#[test]
 fn contract_open_interest_list_entry() {
     let fixture = serde_json::json!({
         "base": "s",
@@ -763,6 +1511,21 @@ fn contract_open_interest_list_entry() {
         "tokenId": "s",
     });
     assert_roundtrip::<datamaxi::OpenInterestListEntry>(fixture);
+}
+
+#[test]
+fn contract_open_interest_list_entry_missing_required() {
+    let fixture = serde_json::json!({
+        "base": "s",
+        "exchange": "s",
+        "openInterest": 1.5,
+        "openInterestUsd": 1.5,
+        "quote": "s",
+        "symbol": "s",
+        "timestamp": 1,
+        "tokenId": "s",
+    });
+    assert_missing_required::<datamaxi::OpenInterestListEntry>(fixture, "base");
 }
 
 #[test]
@@ -782,6 +1545,25 @@ fn contract_open_interest_list_response() {
         ],
     });
     assert_roundtrip::<datamaxi::OpenInterestListResponse>(fixture);
+}
+
+#[test]
+fn contract_open_interest_list_response_missing_required() {
+    let fixture = serde_json::json!({
+        "data": [
+            {
+                "base": "s",
+                "exchange": "s",
+                "openInterest": 1.5,
+                "openInterestUsd": 1.5,
+                "quote": "s",
+                "symbol": "s",
+                "timestamp": 1,
+                "tokenId": "s",
+            },
+        ],
+    });
+    assert_missing_required::<datamaxi::OpenInterestListResponse>(fixture, "data");
 }
 
 #[test]
@@ -810,6 +1592,31 @@ fn contract_open_interest_overview_response() {
 }
 
 #[test]
+fn contract_open_interest_overview_response_missing_required() {
+    let fixture = serde_json::json!({
+        "data": [
+            {
+                "exchanges": "s",
+                "id": "s",
+                "token": {
+                    "cmc_id": "s",
+                    "icon": "s",
+                    "id": "s",
+                    "name": "s",
+                    "symbol": "s",
+                },
+            },
+        ],
+        "key": "s",
+        "limit": 1,
+        "page": 1,
+        "sort": "s",
+        "total": 1,
+    });
+    assert_missing_required::<datamaxi::OpenInterestOverviewResponse>(fixture, "data");
+}
+
+#[test]
 fn contract_open_interest_overview_view() {
     let fixture = serde_json::json!({
         "exchanges": "s",
@@ -823,6 +1630,22 @@ fn contract_open_interest_overview_view() {
         },
     });
     assert_roundtrip::<datamaxi::OpenInterestOverviewView>(fixture);
+}
+
+#[test]
+fn contract_open_interest_overview_view_missing_required() {
+    let fixture = serde_json::json!({
+        "exchanges": "s",
+        "id": "s",
+        "token": {
+            "cmc_id": "s",
+            "icon": "s",
+            "id": "s",
+            "name": "s",
+            "symbol": "s",
+        },
+    });
+    assert_missing_required::<datamaxi::OpenInterestOverviewView>(fixture, "exchanges");
 }
 
 #[test]
@@ -841,6 +1664,21 @@ fn contract_open_interest_response() {
 }
 
 #[test]
+fn contract_open_interest_response_missing_required() {
+    let fixture = serde_json::json!({
+        "base": "s",
+        "exchange": "s",
+        "openInterest": 1.5,
+        "openInterestUsd": 1.5,
+        "quote": "s",
+        "symbol": "s",
+        "timestamp": 1,
+        "tokenId": "s",
+    });
+    assert_missing_required::<datamaxi::OpenInterestResponse>(fixture, "base");
+}
+
+#[test]
 fn contract_open_interest_summary_exchangesummary() {
     let fixture = serde_json::json!({
         "exchange": "s",
@@ -848,6 +1686,16 @@ fn contract_open_interest_summary_exchangesummary() {
         "tokens": 1,
     });
     assert_roundtrip::<datamaxi::OpenInterestSummaryExchangesummary>(fixture);
+}
+
+#[test]
+fn contract_open_interest_summary_exchangesummary_missing_required() {
+    let fixture = serde_json::json!({
+        "exchange": "s",
+        "openInterestUsd": 1.5,
+        "tokens": 1,
+    });
+    assert_missing_required::<datamaxi::OpenInterestSummaryExchangesummary>(fixture, "exchange");
 }
 
 #[test]
@@ -879,6 +1727,34 @@ fn contract_open_interest_summary_response() {
 }
 
 #[test]
+fn contract_open_interest_summary_response_missing_required() {
+    let fixture = serde_json::json!({
+        "exchanges": [
+            {
+                "exchange": "s",
+                "openInterestUsd": 1.5,
+                "tokens": 1,
+            },
+        ],
+        "generatedAt": 1,
+        "grandTotal": 1.5,
+        "tokens": [
+            {
+                "base": "s",
+                "icon": "s",
+                "name": "s",
+                "openInterestUsd": 1.5,
+                "symbol": "s",
+                "tokenId": "s",
+                "venues": 1,
+            },
+        ],
+        "totalTokens": 1,
+    });
+    assert_missing_required::<datamaxi::OpenInterestSummaryResponse>(fixture, "exchanges");
+}
+
+#[test]
 fn contract_open_interest_summary_tokensummary() {
     let fixture = serde_json::json!({
         "base": "s",
@@ -890,6 +1766,20 @@ fn contract_open_interest_summary_tokensummary() {
         "venues": 1,
     });
     assert_roundtrip::<datamaxi::OpenInterestSummaryTokensummary>(fixture);
+}
+
+#[test]
+fn contract_open_interest_summary_tokensummary_missing_required() {
+    let fixture = serde_json::json!({
+        "base": "s",
+        "icon": "s",
+        "name": "s",
+        "openInterestUsd": 1.5,
+        "symbol": "s",
+        "tokenId": "s",
+        "venues": 1,
+    });
+    assert_missing_required::<datamaxi::OpenInterestSummaryTokensummary>(fixture, "base");
 }
 
 #[test]
@@ -972,6 +1862,88 @@ fn contract_premium_detail() {
         "tv": 1.5,
     });
     assert_roundtrip::<datamaxi::PremiumDetail>(fixture);
+}
+
+#[test]
+fn contract_premium_detail_missing_required() {
+    let fixture = serde_json::json!({
+        "bid": "s",
+        "d": 1,
+        "fg": 1.5,
+        "nfr": 1.5,
+        "pdp": 1.5,
+        "pdp15m": 1.5,
+        "pdp1h": 1.5,
+        "pdp24h": 1.5,
+        "pdp30m": 1.5,
+        "pdp4h": 1.5,
+        "pdp5m": 1.5,
+        "pmd": 1,
+        "sad": 1.5,
+        "sad2p": 1.5,
+        "sadf": 1.5,
+        "sb": "s",
+        "sbd2p": 1.5,
+        "sc": "s",
+        "se": "s",
+        "sfr": 1.5,
+        "sfri": 1,
+        "sfrt": 1,
+        "shb": 1.5,
+        "sla": 1.5,
+        "sm": "s",
+        "sms": true,
+        "snd": 1,
+        "soi": 1.5,
+        "soich1h": 1.5,
+        "soich24h": 1.5,
+        "soich4h": 1.5,
+        "soivr": 1.5,
+        "sp": 1.5,
+        "spa": "s",
+        "spdp15m": 1.5,
+        "spdp1h": 1.5,
+        "spdp24h": 1.5,
+        "spdp30m": 1.5,
+        "spdp4h": 1.5,
+        "spdp5m": 1.5,
+        "sq": "s",
+        "st": 1,
+        "sv": 1.5,
+        "t": true,
+        "tad2p": 1.5,
+        "tb": "s",
+        "tbd": 1.5,
+        "tbd2p": 1.5,
+        "tbdf": 1.5,
+        "tc": "s",
+        "te": "s",
+        "tfr": 1.5,
+        "tfri": 1,
+        "tfrt": 1,
+        "thb": 1.5,
+        "tla": 1.5,
+        "tm": "s",
+        "tms": true,
+        "tnd": 1,
+        "toi": 1.5,
+        "toich1h": 1.5,
+        "toich24h": 1.5,
+        "toich4h": 1.5,
+        "toivr": 1.5,
+        "tp": 1.5,
+        "tpa": "s",
+        "tpdp15m": 1.5,
+        "tpdp1h": 1.5,
+        "tpdp24h": 1.5,
+        "tpdp30m": 1.5,
+        "tpdp4h": 1.5,
+        "tpdp5m": 1.5,
+        "tq": "s",
+        "tt": 1,
+        "tv": 1.5,
+    });
+    assert_missing_required::<datamaxi::PremiumDetail>(fixture, "bid");
 }
 
 #[test]
@@ -1072,6 +2044,103 @@ fn contract_premium_response() {
 }
 
 #[test]
+fn contract_premium_response_missing_required() {
+    let fixture = serde_json::json!({
+        "conversion_base": "s",
+        "currency": "s",
+        "data": [
+            {
+                "detail": {
+                    "bid": "s",
+                    "d": 1,
+                    "fg": 1.5,
+                    "nfr": 1.5,
+                    "pdp": 1.5,
+                    "pdp15m": 1.5,
+                    "pdp1h": 1.5,
+                    "pdp24h": 1.5,
+                    "pdp30m": 1.5,
+                    "pdp4h": 1.5,
+                    "pdp5m": 1.5,
+                    "pmd": 1,
+                    "sad": 1.5,
+                    "sad2p": 1.5,
+                    "sadf": 1.5,
+                    "sb": "s",
+                    "sbd2p": 1.5,
+                    "sc": "s",
+                    "se": "s",
+                    "sfr": 1.5,
+                    "sfri": 1,
+                    "sfrt": 1,
+                    "shb": 1.5,
+                    "sla": 1.5,
+                    "sm": "s",
+                    "sms": true,
+                    "snd": 1,
+                    "soi": 1.5,
+                    "soich1h": 1.5,
+                    "soich24h": 1.5,
+                    "soich4h": 1.5,
+                    "soivr": 1.5,
+                    "sp": 1.5,
+                    "spa": "s",
+                    "spdp15m": 1.5,
+                    "spdp1h": 1.5,
+                    "spdp24h": 1.5,
+                    "spdp30m": 1.5,
+                    "spdp4h": 1.5,
+                    "spdp5m": 1.5,
+                    "sq": "s",
+                    "st": 1,
+                    "sv": 1.5,
+                    "t": true,
+                    "tad2p": 1.5,
+                    "tb": "s",
+                    "tbd": 1.5,
+                    "tbd2p": 1.5,
+                    "tbdf": 1.5,
+                    "tc": "s",
+                    "te": "s",
+                    "tfr": 1.5,
+                    "tfri": 1,
+                    "tfrt": 1,
+                    "thb": 1.5,
+                    "tla": 1.5,
+                    "tm": "s",
+                    "tms": true,
+                    "tnd": 1,
+                    "toi": 1.5,
+                    "toich1h": 1.5,
+                    "toich24h": 1.5,
+                    "toich4h": 1.5,
+                    "toivr": 1.5,
+                    "tp": 1.5,
+                    "tpa": "s",
+                    "tpdp15m": 1.5,
+                    "tpdp1h": 1.5,
+                    "tpdp24h": 1.5,
+                    "tpdp30m": 1.5,
+                    "tpdp4h": 1.5,
+                    "tpdp5m": 1.5,
+                    "tq": "s",
+                    "tt": 1,
+                    "tv": 1.5,
+                },
+                "source_annualized_funding_rate": 1.5,
+                "target_annualized_funding_rate": 1.5,
+            },
+        ],
+        "key": "s",
+        "limit": 1,
+        "page": 1,
+        "sort": "s",
+        "total": 1,
+    });
+    assert_missing_required::<datamaxi::PremiumResponse>(fixture, "data");
+}
+
+#[test]
 fn contract_premium_view() {
     let fixture = serde_json::json!({
         "detail": {
@@ -1158,6 +2227,92 @@ fn contract_premium_view() {
 }
 
 #[test]
+fn contract_premium_view_missing_required() {
+    let fixture = serde_json::json!({
+        "detail": {
+            "bid": "s",
+            "d": 1,
+            "fg": 1.5,
+            "nfr": 1.5,
+            "pdp": 1.5,
+            "pdp15m": 1.5,
+            "pdp1h": 1.5,
+            "pdp24h": 1.5,
+            "pdp30m": 1.5,
+            "pdp4h": 1.5,
+            "pdp5m": 1.5,
+            "pmd": 1,
+            "sad": 1.5,
+            "sad2p": 1.5,
+            "sadf": 1.5,
+            "sb": "s",
+            "sbd2p": 1.5,
+            "sc": "s",
+            "se": "s",
+            "sfr": 1.5,
+            "sfri": 1,
+            "sfrt": 1,
+            "shb": 1.5,
+            "sla": 1.5,
+            "sm": "s",
+            "sms": true,
+            "snd": 1,
+            "soi": 1.5,
+            "soich1h": 1.5,
+            "soich24h": 1.5,
+            "soich4h": 1.5,
+            "soivr": 1.5,
+            "sp": 1.5,
+            "spa": "s",
+            "spdp15m": 1.5,
+            "spdp1h": 1.5,
+            "spdp24h": 1.5,
+            "spdp30m": 1.5,
+            "spdp4h": 1.5,
+            "spdp5m": 1.5,
+            "sq": "s",
+            "st": 1,
+            "sv": 1.5,
+            "t": true,
+            "tad2p": 1.5,
+            "tb": "s",
+            "tbd": 1.5,
+            "tbd2p": 1.5,
+            "tbdf": 1.5,
+            "tc": "s",
+            "te": "s",
+            "tfr": 1.5,
+            "tfri": 1,
+            "tfrt": 1,
+            "thb": 1.5,
+            "tla": 1.5,
+            "tm": "s",
+            "tms": true,
+            "tnd": 1,
+            "toi": 1.5,
+            "toich1h": 1.5,
+            "toich24h": 1.5,
+            "toich4h": 1.5,
+            "toivr": 1.5,
+            "tp": 1.5,
+            "tpa": "s",
+            "tpdp15m": 1.5,
+            "tpdp1h": 1.5,
+            "tpdp24h": 1.5,
+            "tpdp30m": 1.5,
+            "tpdp4h": 1.5,
+            "tpdp5m": 1.5,
+            "tq": "s",
+            "tt": 1,
+            "tv": 1.5,
+        },
+        "source_annualized_funding_rate": 1.5,
+        "target_annualized_funding_rate": 1.5,
+    });
+    assert_missing_required::<datamaxi::PremiumView>(fixture, "detail");
+}
+
+#[test]
 fn contract_telegram_channels_response() {
     let fixture = serde_json::json!({
         "category": "s",
@@ -1182,6 +2337,30 @@ fn contract_telegram_channels_response() {
 }
 
 #[test]
+fn contract_telegram_channels_response_missing_required() {
+    let fixture = serde_json::json!({
+        "category": "s",
+        "data": [
+            {
+                "category": "s",
+                "channelName": "s",
+                "channelTitle": "s",
+                "createdAt": 1,
+                "description": "s",
+                "link": "s",
+                "subscribers": 1,
+            },
+        ],
+        "key": "s",
+        "limit": 1,
+        "page": 1,
+        "sort": "s",
+        "total": 1,
+    });
+    assert_missing_required::<datamaxi::TelegramChannelsResponse>(fixture, "data");
+}
+
+#[test]
 fn contract_telegram_channels_view() {
     let fixture = serde_json::json!({
         "category": "s",
@@ -1193,6 +2372,20 @@ fn contract_telegram_channels_view() {
         "subscribers": 1,
     });
     assert_roundtrip::<datamaxi::TelegramChannelsView>(fixture);
+}
+
+#[test]
+fn contract_telegram_channels_view_missing_required() {
+    let fixture = serde_json::json!({
+        "category": "s",
+        "channelName": "s",
+        "channelTitle": "s",
+        "createdAt": 1,
+        "description": "s",
+        "link": "s",
+        "subscribers": 1,
+    });
+    assert_missing_required::<datamaxi::TelegramChannelsView>(fixture, "category");
 }
 
 #[test]
@@ -1223,6 +2416,33 @@ fn contract_telegram_messages_response() {
 }
 
 #[test]
+fn contract_telegram_messages_response_missing_required() {
+    let fixture = serde_json::json!({
+        "category": "s",
+        "data": [
+            {
+                "channelHandle": "s",
+                "channelId": "s",
+                "channelName": "s",
+                "forwards": 1,
+                "message": "s",
+                "messageId": "s",
+                "messageLink": "s",
+                "publishedAt": 1,
+                "reactions": 1,
+                "views": 1,
+            },
+        ],
+        "key": "s",
+        "limit": 1,
+        "page": 1,
+        "sort": "s",
+        "total": 1,
+    });
+    assert_missing_required::<datamaxi::TelegramMessagesResponse>(fixture, "data");
+}
+
+#[test]
 fn contract_telegram_messages_view() {
     let fixture = serde_json::json!({
         "channelHandle": "s",
@@ -1237,6 +2457,23 @@ fn contract_telegram_messages_view() {
         "views": 1,
     });
     assert_roundtrip::<datamaxi::TelegramMessagesView>(fixture);
+}
+
+#[test]
+fn contract_telegram_messages_view_missing_required() {
+    let fixture = serde_json::json!({
+        "channelHandle": "s",
+        "channelId": "s",
+        "channelName": "s",
+        "forwards": 1,
+        "message": "s",
+        "messageId": "s",
+        "messageLink": "s",
+        "publishedAt": 1,
+        "reactions": 1,
+        "views": 1,
+    });
+    assert_missing_required::<datamaxi::TelegramMessagesView>(fixture, "channelHandle");
 }
 
 #[test]
@@ -1266,6 +2503,32 @@ fn contract_ticker_response() {
 }
 
 #[test]
+fn contract_ticker_response_missing_required() {
+    let fixture = serde_json::json!({
+        "currency": "s",
+        "data": {
+            "b": "s",
+            "d": 1,
+            "e": "s",
+            "hb": 1.5,
+            "la": 1.5,
+            "ld": 1.5,
+            "m": "s",
+            "p": 1.5,
+            "p24h": 1.5,
+            "pc": 1.5,
+            "q": "s",
+            "s": "s",
+            "ud": 1.5,
+            "v": 1.5,
+        },
+        "market": "s",
+        "src": "s",
+    });
+    assert_missing_required::<datamaxi::TickerResponse>(fixture, "currency");
+}
+
+#[test]
 fn contract_ticker_view() {
     let fixture = serde_json::json!({
         "b": "s",
@@ -1287,6 +2550,27 @@ fn contract_ticker_view() {
 }
 
 #[test]
+fn contract_ticker_view_missing_required() {
+    let fixture = serde_json::json!({
+        "b": "s",
+        "d": 1,
+        "e": "s",
+        "hb": 1.5,
+        "la": 1.5,
+        "ld": 1.5,
+        "m": "s",
+        "p": 1.5,
+        "p24h": 1.5,
+        "pc": 1.5,
+        "q": "s",
+        "s": "s",
+        "ud": 1.5,
+        "v": 1.5,
+    });
+    assert_missing_required::<datamaxi::TickerView>(fixture, "b");
+}
+
+#[test]
 fn contract_token_detail() {
     let fixture = serde_json::json!({
         "cmc_id": "s",
@@ -1296,6 +2580,18 @@ fn contract_token_detail() {
         "symbol": "s",
     });
     assert_roundtrip::<datamaxi::TokenDetail>(fixture);
+}
+
+#[test]
+fn contract_token_detail_missing_required() {
+    let fixture = serde_json::json!({
+        "cmc_id": "s",
+        "icon": "s",
+        "id": "s",
+        "name": "s",
+        "symbol": "s",
+    });
+    assert_missing_required::<datamaxi::TokenDetail>(fixture, "icon");
 }
 
 #[test]
@@ -1311,4 +2607,19 @@ fn contract_wallet_status_view() {
         "withdraw_state": "s",
     });
     assert_roundtrip::<datamaxi::WalletStatusView>(fixture);
+}
+
+#[test]
+fn contract_wallet_status_view_missing_required() {
+    let fixture = serde_json::json!({
+        "currency": "s",
+        "deposit_message": "s",
+        "deposit_state": "s",
+        "exchange": "s",
+        "network": "s",
+        "updated_at": 1,
+        "withdraw_message": "s",
+        "withdraw_state": "s",
+    });
+    assert_missing_required::<datamaxi::WalletStatusView>(fixture, "currency");
 }


### PR DESCRIPTION
Automated codegen sync from **datamaxi-codegen**.

The committed `src/generated.rs` and/or `tests/generated_contract.rs`
had drifted from the current `Bisonai/datamaxi-backend` OpenAPI spec.
This PR regenerates both via `make update-rust`.

`tests/generated_contract.rs` holds serde round-trip wire-contract
tests emitted from the same manifest as the structs, so a
rename/retype updates the struct and its test together — this sync PR
stays green instead of breaking on a hand-written per-field assertion.

Triggering codegen run:
https://github.com/Bisonai/datamaxi-codegen/actions/runs/28846297558

Do not edit `src/generated.rs` or `tests/generated_contract.rs` by
hand — both are generated. Re-run the codegen workflow to refresh.