### PR TITLE
Sync generated Rust with backend spec

### DIFF
--- a/src/generated.rs
+++ b/src/generated.rs
@@ -2550,10 +2550,10 @@ pub struct FundingRateHistoryOptions {
     pub page: Option<i64>,
     /// Specifies limit (e.g. `1000`)
     pub limit: Option<i64>,
-    /// Specifies from (e.g. `2021-01-01`)
-    pub from: Option<String>,
-    /// Specifies to (e.g. `2021-01-01`)
-    pub to: Option<String>,
+    /// Specifies from (unix seconds) (e.g. `1735657200`)
+    pub from: Option<i64>,
+    /// Specifies to (unix seconds) (e.g. `1735693200`)
+    pub to: Option<i64>,
     /// Specifies sort (e.g. `asc`)
     pub sort: Option<FundingRateHistorySort>,
 }
@@ -2579,13 +2579,13 @@ impl FundingRateHistoryOptions {
         self
     }
 
-    pub fn from(mut self, from: impl Into<String>) -> Self {
-        self.from = Some(from.into());
+    pub fn from(mut self, from: i64) -> Self {
+        self.from = Some(from);
         self
     }
 
-    pub fn to(mut self, to: impl Into<String>) -> Self {
-        self.to = Some(to.into());
+    pub fn to(mut self, to: i64) -> Self {
+        self.to = Some(to);
         self
     }
 
@@ -2650,10 +2650,10 @@ impl IndexPrice {
 
 #[derive(Default, Clone)]
 pub struct IndexPriceOptions {
-    /// Specifies from (e.g. `2021-01-01`)
-    pub from: Option<String>,
-    /// Specifies to (e.g. `2021-01-01`)
-    pub to: Option<String>,
+    /// Specifies from (unix seconds) (e.g. `1735657200`)
+    pub from: Option<i64>,
+    /// Specifies to (unix seconds) (e.g. `1735693200`)
+    pub to: Option<i64>,
     /// interval (e.g. `5m`)
     pub interval: Option<String>,
 }
@@ -2667,13 +2667,13 @@ impl IndexPriceOptions {
         }
     }
 
-    pub fn from(mut self, from: impl Into<String>) -> Self {
-        self.from = Some(from.into());
+    pub fn from(mut self, from: i64) -> Self {
+        self.from = Some(from);
         self
     }
 
-    pub fn to(mut self, to: impl Into<String>) -> Self {
-        self.to = Some(to.into());
+    pub fn to(mut self, to: i64) -> Self {
+        self.to = Some(to);
         self
     }
 


### PR DESCRIPTION
Automated codegen sync from **datamaxi-codegen**.

The committed `src/generated.rs` and/or `tests/generated_contract.rs`
had drifted from the current `Bisonai/datamaxi-backend` OpenAPI spec.
This PR regenerates both via `make update-rust`.

`tests/generated_contract.rs` holds serde round-trip wire-contract
tests emitted from the same manifest as the structs, so a
rename/retype updates the struct and its test together — this sync PR
stays green instead of breaking on a hand-written per-field assertion.

Triggering codegen run:
https://github.com/Bisonai/datamaxi-codegen/actions/runs/28847976683

Do not edit `src/generated.rs` or `tests/generated_contract.rs` by
hand — both are generated. Re-run the codegen workflow to refresh.