### PR TITLE
chore: add package metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,13 @@ edition = "2021"
 rust-version = "1.86"
 readme = "README.md"
 license = "MIT"
+description = "Official Rust SDK for the DataMaxi+ API: fetch historical and latest crypto/market data."
+repository = "https://github.com/Bisonai/datamaxi-rust"
+documentation = "https://docs.rs/datamaxi"
+homepage = "https://datamaxiplus.com/"
+keywords = ["datamaxi", "crypto", "api", "sdk", "trading"]
+categories = ["api-bindings"]
+authors = ["Bisonai"]
 
 [dependencies]
 reqwest = { version = "0.12.7", features = ["json"] }


### PR DESCRIPTION
Adds crates.io metadata to [package]: description, repository, documentation, homepage, keywords, categories, authors. No publish, no README/CI changes.

Checks:
- cargo fmt --all -- --check: pass
- cargo clippy --all-targets --all-features -- -D warnings: pass
- cargo test --all-targets: pass (all suites green)
- cargo publish --dry-run: pass (packaged/verified, upload aborted as expected for dry run)

Closes #99