### PR TITLE
feat: async Stream for Paginator + total-less envelope pagination

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,17 @@ tokio = { version = "1", default-features = false, features = ["time"] }
 # Optional: request-level spans/events in `get_loop!`, behind the `tracing`
 # feature. Compiles away entirely (no dependency pulled in) when disabled.
 tracing = { version = "0.1", optional = true }
+# Optional: `futures::Stream` impl for the async `Paginator`, behind the
+# `stream` feature. Only `futures-core` (the trait, no executor/combinators)
+# is pulled in; MSRV well under our 1.86 floor. Compiles away entirely when
+# disabled.
+futures-core = { version = "0.3", optional = true }
 
 [features]
 default = []
 blocking = ["reqwest/blocking"]
 tracing = ["dep:tracing"]
+stream = ["dep:futures-core"]
 
 [dev-dependencies]
 dotenvy = "0.15.7"
@@ -41,3 +47,6 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 # Unconditional dev-dependency so tests can assert on emitted spans/events
 # when built with `--features tracing`; does not affect release builds.
 tracing = "0.1"
+# Unconditional dev-dependency so the `stream`-gated pagination test can drive
+# the `Stream` impl with `StreamExt::next`; does not affect release builds.
+futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ Two independent, opt-in hooks:
   let client = ClientBuilder::new().api_key("my_api_key").http_client(http).build()?;
   ```
 
+### Pagination
+
+`Client::paginate` / `blocking::Client::paginate` auto-paginate any paged
+response envelope, with or without a reported `total`. The async paginator
+is a plain `next_page()` cursor by default; enable the opt-in `stream`
+feature to also drive it as a `futures::Stream` (adds no dependency unless
+enabled):
+
+```toml
+[dependencies]
+datamaxi = { git = "https://github.com/bisonai/datamaxi-rust.git", features = ["stream"] }
+```
+
 ### Minimum Supported Rust Version (MSRV)
 
 This crate requires **Rust 1.86** or newer. The MSRV is verified in CI and

--- a/src/api.rs
+++ b/src/api.rs
@@ -14,6 +14,19 @@
 //!   custom auth, metrics, or logging middleware. When omitted, the client
 //!   falls back to the built-in defaults (`User-Agent`, unbounded idle pool,
 //!   the configured timeout).
+//!
+//! ## Pagination
+//!
+//! [`Client::paginate`] / [`blocking::Client::paginate`] auto-paginate any
+//! [`Paginated`] response envelope, whether or not it reports a `total` (see
+//! [`Paginated::total`]). The async [`Paginator`] is a plain `next_page()`
+//! cursor by default; enabling the opt-in **`stream` feature** additionally
+//! implements
+//! [`Stream`](https://docs.rs/futures-core/latest/futures_core/stream/trait.Stream.html)
+//! for it, so it composes with `futures`/`StreamExt` combinators and
+//! `.next().await`. Off by default and compiles away entirely (no
+//! `futures-core` dependency pulled in) when disabled. The blocking
+//! [`blocking::Paginator`] already implements [`Iterator`] unconditionally.
 
 use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
@@ -460,16 +473,16 @@ impl Client {
     }
 }
 
-/// Implemented by paged response envelopes — the `page`/`limit`/`total`/`data`
-/// shape shared by several Datamaxi+ endpoints (e.g. `CexAnnouncementsResponse`) —
-/// so [`Client::paginate`] / [`blocking::Client::paginate`] can drive a generic
-/// auto-paginator over them without codegen needing to emit a bespoke helper
-/// per endpoint.
+/// Implemented by paged response envelopes — the `page`/`limit`/`data` shape
+/// shared by several Datamaxi+ endpoints, with or without a `total` (e.g.
+/// `CexAnnouncementsResponse` reports `total`; `FundingRateHistoryResponse`
+/// does not) — so [`Client::paginate`] / [`blocking::Client::paginate`] can
+/// drive a generic auto-paginator over them without codegen needing to emit a
+/// bespoke helper per endpoint.
 ///
-/// Only response envelopes that report all three of `page`, `limit`, and
-/// `total` implement this trait today; a handful of generated responses carry
-/// `page`/`limit`/`data` without a `total` (e.g. `FundingRateHistoryResponse`)
-/// and are not yet covered — see the crate's pagination docs.
+/// Envelopes without a `total` (see [`Paginated::total`]) auto-paginate the
+/// same way, just terminating only on an empty page rather than also on
+/// `page * limit >= total`.
 pub trait Paginated {
     /// The item type yielded per page (the envelope's `data` element type).
     type Item;
@@ -489,6 +502,10 @@ pub trait Paginated {
 
 /// Implements [`Paginated`] for a `page`/`limit`/`total`/`data` response
 /// envelope, mapping its fields directly (`data` -> items).
+///
+/// A second arm, `impl_paginated!($response, $item, no_total)`, covers the
+/// `page`/`limit`/`data` shape without a `total` field: [`Paginated::total`]
+/// returns `None`, so [`consume_page`] terminates only on an empty page.
 macro_rules! impl_paginated {
     ($response:ty, $item:ty) => {
         impl Paginated for $response {
@@ -504,6 +521,27 @@ macro_rules! impl_paginated {
 
             fn total(&self) -> Option<i64> {
                 Some(self.total)
+            }
+
+            fn into_items(self) -> Vec<Self::Item> {
+                self.data
+            }
+        }
+    };
+    ($response:ty, $item:ty, no_total) => {
+        impl Paginated for $response {
+            type Item = $item;
+
+            fn page(&self) -> i64 {
+                self.page
+            }
+
+            fn limit(&self) -> i64 {
+                self.limit
+            }
+
+            fn total(&self) -> Option<i64> {
+                None
             }
 
             fn into_items(self) -> Vec<Self::Item> {
@@ -537,11 +575,15 @@ impl_paginated!(
     crate::generated::TelegramMessagesResponse,
     crate::generated::TelegramMessagesView
 );
+impl_paginated!(
+    crate::generated::FundingRateHistoryResponse,
+    crate::generated::FundingRateHistoryView,
+    no_total
+);
 
 /// Async auto-paginator returned by [`Client::paginate`].
 ///
-/// Not a [`futures::Stream`](https://docs.rs/futures) — the crate takes no
-/// dependency on `futures` for this — `next_page` is a plain cursor:
+/// `next_page` is a plain cursor, with no dependency on `futures`:
 ///
 /// ```no_run
 /// use datamaxi::api::ClientBuilder;
@@ -561,6 +603,34 @@ impl_paginated!(
 /// # Ok(())
 /// # }
 /// ```
+///
+/// With the opt-in `stream` feature, [`Paginator`] also implements
+/// [`Stream`](https://docs.rs/futures-core/latest/futures_core/stream/trait.Stream.html)
+/// (the trait re-exported as `futures::Stream` by the
+/// [`futures`](https://docs.rs/futures) crate), yielding one
+/// `Result<Vec<T::Item>>` per page, so it composes with `futures`/`StreamExt`
+/// combinators and `.next().await`:
+///
+/// ```no_run
+/// # #[cfg(feature = "stream")]
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// use datamaxi::api::ClientBuilder;
+/// use datamaxi::CexAnnouncementsResponse;
+/// use futures::StreamExt;
+/// use std::collections::BTreeMap;
+///
+/// let client = ClientBuilder::new().api_key("my_api_key").build()?;
+/// let mut pages = client
+///     .paginate::<CexAnnouncementsResponse>("/api/v1/cex/announcements", BTreeMap::new());
+///
+/// while let Some(page) = pages.next().await {
+///     for item in page? {
+///         println!("{}", item.title);
+///     }
+/// }
+/// # Ok(())
+/// # }
+/// ```
 pub struct Paginator<T: Paginated> {
     client: Client,
     endpoint: String,
@@ -568,6 +638,12 @@ pub struct Paginator<T: Paginated> {
     next_page: i64,
     done: bool,
     _marker: PhantomData<T>,
+    /// The in-flight `next_page()` future backing [`futures_core::Stream::poll_next`],
+    /// present only under the `stream` feature. Built from owned clones of
+    /// `client`/`endpoint`/`params` (rather than borrowing `self`) so it can
+    /// be stored across `poll_next` calls without a self-referential struct.
+    #[cfg(feature = "stream")]
+    pending: Option<std::pin::Pin<Box<dyn std::future::Future<Output = Result<T>> + Send>>>,
 }
 
 impl<T> Paginator<T>
@@ -583,6 +659,8 @@ where
             next_page,
             done: false,
             _marker: PhantomData,
+            #[cfg(feature = "stream")]
+            pending: None,
         }
     }
 
@@ -608,6 +686,71 @@ where
     /// flavors share the exact same terminal-condition logic.
     fn consume_response(&mut self, response: T) -> Option<Vec<T::Item>> {
         consume_page(&mut self.next_page, &mut self.done, response)
+    }
+}
+
+/// [`futures_core::Stream`] over [`Paginator`]'s pages, gated by the `stream`
+/// feature so the `futures-core` dependency stays opt-in. Yields one
+/// `Result<Vec<T::Item>>` per page and, like [`Iterator`] for
+/// [`blocking::Paginator`], stops (yields `None`) once the server reports no
+/// more data, and after the first `Err`.
+///
+/// Each poll drives an owned future built from clones of `client`/`endpoint`/
+/// `params` (see [`Paginator::pending`]) rather than borrowing `self`, so the
+/// future can be stored across `poll_next` calls without a self-referential
+/// struct; on `Poll::Ready`, the same [`consume_page`] bookkeeping used by
+/// `next_page` updates `next_page`/`done`.
+#[cfg(feature = "stream")]
+impl<T> futures_core::Stream for Paginator<T>
+where
+    T: Paginated + DeserializeOwned + Send + Unpin + 'static,
+{
+    type Item = Result<Vec<T::Item>>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        use std::task::Poll;
+
+        let this = self.get_mut();
+
+        if this.done {
+            return Poll::Ready(None);
+        }
+
+        if this.pending.is_none() {
+            let client = this.client.clone();
+            let endpoint = this.endpoint.clone();
+            let mut params = this.params.clone();
+            params.insert("page".to_string(), this.next_page.to_string());
+            this.pending = Some(Box::pin(async move {
+                client.get::<T>(&endpoint, Some(params)).await
+            }));
+        }
+
+        let pending = this
+            .pending
+            .as_mut()
+            .expect("pending future was just set above");
+        match pending.as_mut().poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(result) => {
+                this.pending = None;
+                match result {
+                    Ok(response) => Poll::Ready(
+                        consume_page(&mut this.next_page, &mut this.done, response).map(Ok),
+                    ),
+                    Err(error) => {
+                        // Stop the stream after an error rather than retrying
+                        // the same page forever, mirroring the blocking
+                        // `Iterator` impl.
+                        this.done = true;
+                        Poll::Ready(Some(Err(error)))
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/tests/pagination.rs
+++ b/tests/pagination.rs
@@ -1,13 +1,18 @@
 //! Integration tests for the auto-paginator added for issue #88
-//! ([`datamaxi::api::Client::paginate`] / [`datamaxi::api::blocking::Client::paginate`]).
+//! ([`datamaxi::api::Client::paginate`] / [`datamaxi::api::blocking::Client::paginate`]),
+//! plus the total-less envelope coverage and `stream` feature added for
+//! issue #102.
 //!
 //! These drive a real `page`/`limit`/`total`/`data` envelope
 //! (`CexAnnouncementsResponse`) through a mock server and lock: multi-page
 //! traversal, the `page * limit >= total` terminal condition, the empty-page
-//! terminal condition, and honoring a caller-supplied starting page.
+//! terminal condition, and honoring a caller-supplied starting page. A
+//! separate test drives `FundingRateHistoryResponse`, a `page`/`limit`/`data`
+//! envelope with no `total`, confirming it also auto-paginates and terminates
+//! on an empty page.
 
 use datamaxi::api::{Client, ClientBuilder};
-use datamaxi::CexAnnouncementsResponse;
+use datamaxi::{CexAnnouncementsResponse, FundingRateHistoryResponse};
 use mockito::Matcher;
 use std::collections::BTreeMap;
 
@@ -208,4 +213,109 @@ fn blocking_paginate_walks_multiple_pages_until_total_reached() {
 
     page1.assert();
     page2.assert();
+}
+
+// --- Total-less envelopes (issue #102) ----------------------------------
+
+/// A page body for `FundingRateHistoryResponse`: `n` funding-rate points,
+/// plus the envelope's `page`/`limit`/`data` (no `total` field).
+fn funding_rate_history_page_body(page: i64, limit: i64, n: usize) -> String {
+    let data: Vec<String> = (0..n).map(|i| format!(r#"{{"d":{i},"f":0.01}}"#)).collect();
+    format!(
+        r#"{{"data":[{}],"exchange":"binance","limit":{limit},"page":{page},"sort":"asc","symbol":"BTCUSDT"}}"#,
+        data.join(",")
+    )
+}
+
+/// `FundingRateHistoryResponse` has no `total` field, so the paginator must
+/// rely solely on the empty-page terminal condition: it walks forward while
+/// pages return data, then stops on the first empty page.
+#[tokio::test]
+async fn paginate_walks_total_less_envelope_until_empty_page() {
+    let mut server = mockito::Server::new_async().await;
+
+    let page1 = server
+        .mock("GET", "/api/v1/funding-rate/history")
+        .match_query(Matcher::UrlEncoded("page".into(), "1".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(funding_rate_history_page_body(1, 2, 2))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let page2 = server
+        .mock("GET", "/api/v1/funding-rate/history")
+        .match_query(Matcher::UrlEncoded("page".into(), "2".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(funding_rate_history_page_body(2, 2, 0))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let client = mock_client(server.url());
+    let mut pages = client
+        .paginate::<FundingRateHistoryResponse>("/api/v1/funding-rate/history", BTreeMap::new());
+
+    let first = pages.next_page().await.expect("first page ok");
+    assert_eq!(first.map(|items| items.len()), Some(2));
+
+    let second = pages.next_page().await.expect("empty page ok");
+    assert!(second.is_none(), "empty page must terminate the paginator");
+
+    page1.assert_async().await;
+    page2.assert_async().await;
+}
+
+// --- Async Stream support (issue #102), `stream` feature ----------------
+
+/// [`Paginator`](datamaxi::api::Paginator) implements [`futures::Stream`]
+/// under the `stream` feature: `.next().await` walks pages the same way
+/// `next_page()` does, stopping once the server has no more data.
+#[cfg(feature = "stream")]
+#[tokio::test]
+async fn paginate_stream_walks_multiple_pages_until_total_reached() {
+    use futures::StreamExt;
+
+    let mut server = mockito::Server::new_async().await;
+
+    let page1 = server
+        .mock("GET", "/api/v1/cex/announcements")
+        .match_query(Matcher::UrlEncoded("page".into(), "1".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(page_body(1, 2, 3, 2))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let page2 = server
+        .mock("GET", "/api/v1/cex/announcements")
+        .match_query(Matcher::UrlEncoded("page".into(), "2".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(page_body(2, 2, 3, 1))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let client = mock_client(server.url());
+    let mut params = BTreeMap::new();
+    params.insert("limit".to_string(), "2".to_string());
+    let mut pages =
+        client.paginate::<CexAnnouncementsResponse>("/api/v1/cex/announcements", params);
+
+    let first = pages.next().await.expect("first page present");
+    assert_eq!(first.expect("first page ok").len(), 2);
+
+    let second = pages.next().await.expect("second page present");
+    assert_eq!(second.expect("second page ok").len(), 1);
+
+    // Terminal: the stream yields `None` once `total` is reached, without a
+    // third HTTP call.
+    assert!(pages.next().await.is_none());
+
+    page1.assert_async().await;
+    page2.assert_async().await;
 }


### PR DESCRIPTION
Two pagination gaps from the SDK assessment.

**1. Async `Stream`** (opt-in `stream` feature → optional `futures-core`). Async `Paginator` now implements `futures_core::Stream` yielding `Result<Vec<T::Item>>` per page, reusing `consume_page`. `next_page()` unchanged. Default build gains no dependency (verified via `cargo tree`).

**2. Total-less envelopes.** New `no_total` arm of `impl_paginated!` (returns `total() -> None`); added `impl Paginated for FundingRateHistoryResponse` — the only `page`/`limit`/`data`-without-`total` response in `generated.rs` (checked all `*Response` structs). Terminates on empty page.

Tests: total-less walk (mockito) + stream walk (feature-gated, `StreamExt`). Docs: README + module "Pagination" section.

Checks: `fmt` ✅ · `clippy --all-targets --all-features -D warnings` ✅ · `clippy --features stream` ✅ · `test --all-targets` ✅ · `--all-features` ✅ · doctests ✅.

Known caveat: MSRV 1.86 not verified locally (only stable 1.96 available in the agent env); the repo's CI `msrv` job (1.86.0) will gate this. `futures-core` MSRV is well below 1.86.

Closes #102
