### PR TITLE
ci: run doctests in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-targets
       - run: cargo test --all-targets --all-features
+      - run: cargo test --doc --all-features
 
   msrv:
     name: msrv

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,14 +99,17 @@ pub mod generated;
 /// `blocking` feature, a parallel [`blocking`] module offers synchronous
 /// equivalents.
 ///
-/// ```ignore
+/// ```no_run
 /// use datamaxi::{Client, LiquidationHeatmapOptions};
 ///
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("YOUR_API_KEY");
 /// let heatmap = client
 ///     .liquidation()
 ///     .heatmap(LiquidationHeatmapOptions::new())
 ///     .await?;
+/// # Ok(())
+/// # }
 /// ```
 pub use generated::*;
 


### PR DESCRIPTION
Closes #109

## Summary
- test job used `cargo test --all-targets` twice, which excludes doctests (--all-targets = --lib --bins --tests --benches --examples)
- add `cargo test --doc --all-features` step so doc examples compile/run in CI (--all-features needed for the stream-gated example in src/api.rs)
- src/lib.rs:102 doc example (liquidation heatmap) was fenced ```ignore, so rustdoc never compiled it even with the new step. Converted to ```no_run, wrapped in a hidden async fn like the crate-level example at src/lib.rs:43, so it now actually compiles.

## Doctest run (local, cargo test --doc --all-features)
\`\`\`
running 6 tests
test src/api.rs - api::blocking::Paginator (line 1119) - compile ... ok
test src/api.rs - api::ClientBuilder (line 840) - compile ... ok
test src/api.rs - api::Paginator (line 614) - compile ... ok
test src/api.rs - api::Paginator (line 588) - compile ... ok
test src/lib.rs - (line 102) - compile ... ok
test src/lib.rs - (line 43) - compile ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s
\`\`\`
6/6 pass, 0 ignored.