### PR TITLE
Re-export reqwest so http_client callers can name the type

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Two independent, opt-in hooks:
   ```
 - **Custom HTTP client** — `ClientBuilder::http_client` (and the `blocking`
   mirror) let you supply your own pre-built `reqwest::Client`, e.g. wrapped
-  with `reqwest-middleware` for custom auth, metrics, or logging:
+  with `reqwest-middleware` for custom auth, metrics, or logging. Use the
+  crate's re-exported `datamaxi::reqwest` to build it, so the type always
+  matches without a version mismatch:
   ```rust,ignore
-  let http = reqwest::Client::builder().build()?;
+  let http = datamaxi::reqwest::Client::builder().build()?;
   let client = ClientBuilder::new().api_key("my_api_key").http_client(http).build()?;
   ```
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -900,10 +900,12 @@ impl ClientBuilder {
         self
     }
 
-    /// Overrides the internally-built `reqwest::Client` with a caller-supplied
-    /// one — the escape hatch for custom middleware, timeouts, proxies, or
-    /// instrumentation (e.g. a `reqwest-middleware` client wrapped down to its
-    /// inner `reqwest::Client`, or one built with `reqwest_tracing`).
+    /// Overrides the internally-built `datamaxi::reqwest::Client` with a
+    /// caller-supplied one — the escape hatch for custom middleware,
+    /// timeouts, proxies, or instrumentation (e.g. a `reqwest-middleware`
+    /// client wrapped down to its inner `reqwest::Client`, or one built with
+    /// `reqwest_tracing`). Use the crate's re-exported [`crate::reqwest`] to
+    /// build it, so the type always matches without a version mismatch.
     ///
     /// When set, [`ClientBuilder::timeout`] is ignored for HTTP-level
     /// settings (the caller's client is used as-is); [`build`](Self::build)
@@ -1264,9 +1266,11 @@ pub mod blocking {
             self
         }
 
-        /// Overrides the internally-built `reqwest::blocking::Client` with a
-        /// caller-supplied one. Mirrors [`super::ClientBuilder::http_client`]
-        /// for the blocking flavor.
+        /// Overrides the internally-built `datamaxi::reqwest::blocking::Client`
+        /// with a caller-supplied one. Mirrors
+        /// [`super::ClientBuilder::http_client`] for the blocking flavor; use
+        /// the crate's re-exported [`crate::reqwest`] to build it, so the
+        /// type always matches without a version mismatch.
         pub fn http_client(mut self, client: reqwest::blocking::Client) -> Self {
             self.http_client = Some(client);
             self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,3 +114,11 @@ pub use generated::*;
 /// write `datamaxi::Client` / `datamaxi::ClientBuilder`. Endpoint groups hang
 /// off the client via generated accessors, e.g. `client.cex_candle()`.
 pub use api::{Client, ClientBuilder};
+
+/// Re-exported so callers can name the exact `reqwest::Client` /
+/// `reqwest::blocking::Client` type expected by
+/// [`ClientBuilder::http_client`] / `blocking::ClientBuilder::http_client`
+/// (and the `reqwest::Error` wrapped by [`api::Error::Http`]) without adding
+/// `reqwest` to their own `Cargo.toml` and risking a version mismatch with
+/// this crate's dependency.
+pub use reqwest;


### PR DESCRIPTION
Closes #111

## Summary
- `pub use reqwest;` at crate root (src/lib.rs) — callers can now write `datamaxi::reqwest::Client` / `datamaxi::reqwest::blocking::Client` without adding reqwest to their own Cargo.toml or risking a version mismatch.
- Updated doc comments on `ClientBuilder::http_client` and `blocking::ClientBuilder::http_client` (src/api.rs) to reference the re-export.
- Updated README Observability section's http_client example to use `datamaxi::reqwest::Client::builder()`.

Out of scope (deliberately deferred per issue): wrapping `Error::Http` in an opaque type.

## Verification
- `cargo build --all-features` — pass
- `cargo clippy --all-targets --all-features -- -D warnings` — pass, no warnings
- `cargo test --all-features` — pass: unittests 16/16, generated_contract 126/126, live 25/25, pagination 6/6, wire_contract 44/44, doctests 5/5 (1 ignored, pre-existing `no_run` example unaffected)
- `cargo test --doc --all-features` — pass: 5/5 (1 ignored)