### PR TITLE
feat: rustls-tls feature alongside default native-tls

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,3 +50,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --all-features
       - run: cargo test --all-features
+
+  rustls:
+    name: rustls-tls
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --no-default-features --features rustls-tls
+      - run: cargo build --no-default-features --features rustls-tls,blocking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,11 @@ categories = ["api-bindings"]
 authors = ["Bisonai"]
 
 [dependencies]
-reqwest = { version = "0.12.7", features = ["json"] }
+# default-features off so callers can pick `native-tls` (default) or
+# `rustls-tls`; re-enable everything else reqwest's own defaults bring
+# (charset, http2, macos-system-configuration) so opting out of TLS choice
+# is the only behavior change.
+reqwest = { version = "0.12.7", default-features = false, features = ["json", "charset", "http2", "macos-system-configuration"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
 thiserror = "2.0.11"
@@ -35,7 +39,12 @@ tracing = { version = "0.1", optional = true }
 futures-core = { version = "0.3", optional = true }
 
 [features]
-default = []
+default = ["native-tls"]
+# Forwards to reqwest's `default-tls` (not reqwest's own `native-tls`
+# feature) to preserve today's exact behavior without also exposing
+# native-tls types in reqwest's public API.
+native-tls = ["reqwest/default-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
 blocking = ["reqwest/blocking"]
 tracing = ["dep:tracing"]
 stream = ["dep:futures-core"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ wrappers under `datamaxi::blocking`:
 datamaxi = { git = "https://github.com/bisonai/datamaxi-rust.git", features = ["blocking"] }
 ```
 
+### TLS backend
+
+`native-tls` (OpenSSL) is on by default. To use `rustls` instead (e.g. for
+static/`scratch`/distroless builds with no OpenSSL system dependency):
+
+```toml
+[dependencies]
+datamaxi = { git = "https://github.com/bisonai/datamaxi-rust.git", default-features = false, features = ["rustls-tls"] }
+```
+
 ### Observability
 
 Two independent, opt-in hooks:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ static/`scratch`/distroless builds with no OpenSSL system dependency):
 datamaxi = { git = "https://github.com/bisonai/datamaxi-rust.git", default-features = false, features = ["rustls-tls"] }
 ```
 
+`default-features = false` without also selecting `rustls-tls` fails to
+build (no TLS backend selected) rather than silently linking a client
+with no HTTPS support.
+
 ### Observability
 
 Two independent, opt-in hooks:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,3 +125,10 @@ pub use api::{Client, ClientBuilder};
 /// `reqwest` to their own `Cargo.toml` and risking a version mismatch with
 /// this crate's dependency.
 pub use reqwest;
+
+#[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
+compile_error!(
+    "datamaxi requires a TLS backend: enable either the `native-tls` (default) \
+     or `rustls-tls` feature. If you set `default-features = false`, add \
+     `features = [\"rustls-tls\"]`."
+);


### PR DESCRIPTION
Closes #112.

## Summary

reqwest was pulled in with its default features on, which forces
`default-tls` (native-tls -> OpenSSL on Linux) with no way to opt out.
This adds a `rustls-tls` cargo feature that forwards to
`reqwest/rustls-tls`, with `native-tls` kept as the default so existing
users see no behavior change.

- `Cargo.toml`: `reqwest` now `default-features = false`, with `json`,
  `charset`, `http2`, `macos-system-configuration` re-added explicitly
  (reqwest's own default set minus the TLS choice), so disabling
  default-features doesn't silently drop HTTP/2 or charset handling.
- `[features]`: `default = ["native-tls"]`, `native-tls = ["reqwest/default-tls"]`,
  `rustls-tls = ["reqwest/rustls-tls"]`. `blocking`/`tracing`/`stream`
  unchanged and compose with either TLS backend.
- `.github/workflows/rust.yml`: new `rustls-tls` job builds
  `--no-default-features --features rustls-tls` and
  `...,blocking`, proving the rustls-only build actually works (the
  existing `--all-features` steps enable both TLS backends at once and
  don't prove this).
- `README.md`: new "TLS backend" section documenting the opt-in.
- `src/lib.rs`: `compile_error!` guard when neither `native-tls` nor
  `rustls-tls` is enabled (see regression below).

## TLS backend choice rationale

`native-tls` forwards to reqwest's `default-tls` (not reqwest's own
`native-tls` feature). `default-tls` is what today's unqualified
`reqwest = { features = ["json"] }` pulls in; reqwest's separate
`native-tls` feature additionally re-exports native-tls types in
reqwest's public API, which we don't use and don't want to add as new
public surface. Forwarding to `default-tls` reproduces current
behavior exactly.

## Regression found and fixed: no-TLS-backend build silently succeeded

Before this change, `default = []` meant a consumer writing
`default-features = false` was a no-op — reqwest's own defaults still
pulled in `default-tls`, so HTTPS worked either way.

After making `reqwest` itself `default-features = false` and gating TLS
behind our own `native-tls`/`rustls-tls` features, a consumer writing:

```toml
datamaxi = { git = "...", default-features = false, features = ["blocking"] }
```

got a crate that **compiled successfully but had no TLS backend at
all**, failing only at runtime on the first `https://` request with
reqwest's "no TLS backend" error — a working config silently turned
into a runtime-only failure.

Fixed with a `compile_error!` guard at the bottom of `src/lib.rs` (after
`pub use reqwest;`, so it doesn't collide with a concurrent PR adding
`#![cfg_attr(docsrs, feature(doc_cfg))]` at line 1):

```rust
#[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
compile_error!(
    "datamaxi requires a TLS backend: enable either the `native-tls` (default) \
     or `rustls-tls` feature. If you set `default-features = false`, add \
     `features = [\"rustls-tls\"]`."
);
```

Also added a sentence to the README "TLS backend" section noting that
`default-features = false` requires explicitly selecting `rustls-tls`.

## Verification

`cargo build --all-features`
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.78s
```

`cargo build --no-default-features --features rustls-tls`
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.27s
```

`cargo build --no-default-features --features rustls-tls,blocking`
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.72s
```

`cargo tree -e normal --no-default-features --features rustls-tls | grep -iE "openssl|native-tls"`
```
(no output)
```

`cargo tree -e normal --no-default-features --features rustls-tls | grep -i h2`
```
│   ├── h2 v0.4.15
│   │   ├── h2 v0.4.15 (*)
```

`cargo clippy --all-targets --all-features -- -D warnings`
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.78s
```
(no warnings)

`cargo test --all-features`
```
test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.41s   (tests/live.rs)
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s     (tests/pagination.rs)
test result: ok. 44 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s    (tests/wire_contract.rs)
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.09s      (doc-tests)
```

`cargo test --doc --all-features`
```
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.18s
```

`cargo fmt --all -- --check` - clean.

Cargo.lock is gitignored for this crate, so no lockfile diff to commit.

### Regression-guard verification (after the compile_error fix)

`cargo build --no-default-features` — now FAILS as intended:
```
error: datamaxi requires a TLS backend: enable either the `native-tls` (default) or `rustls-tls` feature. If you set `default-features = false`, add `features = ["rustls-tls"]`.
   --> src/lib.rs:130:1
    |
130 | / compile_error!(
131 | |     "datamaxi requires a TLS backend: enable either the `native-tls` (default) \
132 | |      or `rustls-tls` feature. If you set `default-features = false`, add \
133 | |      `features = [\"rustls-tls\"]`."
134 | | );
    | |_^

error: could not compile `datamaxi` (lib) due to 1 previous error
```

`cargo build --no-default-features --features blocking` — now FAILS with the same message:
```
error: datamaxi requires a TLS backend: enable either the `native-tls` (default) or `rustls-tls` feature. If you set `default-features = false`, add `features = ["rustls-tls"]`.
   --> src/lib.rs:130:1
    |
130 | / compile_error!(
131 | |     "datamaxi requires a TLS backend: enable either the `native-tls` (default) \
132 | |      or `rustls-tls` feature. If you set `default-features = false`, add \
133 | |      `features = [\"rustls-tls\"]`."
134 | | );
    | |_^

error: could not compile `datamaxi` (lib) due to 1 previous error
```

`cargo build --no-default-features --features rustls-tls` — still PASSES
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.71s
```

`cargo build --no-default-features --features rustls-tls,blocking` — still PASSES
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.76s
```

`cargo build` (defaults) — still PASSES
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.61s
```

`cargo build --all-features` — still PASSES
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.87s
```

`cargo clippy --all-targets --all-features -- -D warnings` — still passes, no warnings
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.70s
```

`cargo test --doc --all-features` — still 6 passed, 0 ignored
```
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s
```

`cargo fmt --all -- --check` — clean.

## Known failures / caveats

None observed. `tests/live.rs` hit the production DataMaxi+ API with
read-only GETs (expected, per repo convention).
