### PR TITLE
docs: add docs.rs metadata and doc(cfg) feature badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,7 @@ tracing = "0.1"
 # Unconditional dev-dependency so the `stream`-gated pagination test can drive
 # the `Stream` impl with `StreamExt::next`; does not affect release builds.
 futures = "0.3"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/api.rs
+++ b/src/api.rs
@@ -701,6 +701,7 @@ where
 /// struct; on `Poll::Ready`, the same [`consume_page`] bookkeeping used by
 /// `next_page` updates `next_page`/`done`.
 #[cfg(feature = "stream")]
+#[cfg_attr(docsrs, doc(cfg(feature = "stream")))]
 impl<T> futures_core::Stream for Paginator<T>
 where
     T: Paginated + DeserializeOwned + Send + Unpin + 'static,
@@ -1004,6 +1005,7 @@ pub enum Error {
 /// scripts, notebooks, and other callers that don't run an async runtime. The
 /// generated endpoint wrappers under [`crate::generated::blocking`] use this.
 #[cfg(feature = "blocking")]
+#[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 pub mod blocking {
     use super::{
         consume_page, is_retryable_error, is_retryable_status, jittered_backoff_delay,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! # DataMaxi+ Rust SDK
 //!
 //! This is the official implementation of Rust SDK for [DataMaxi+](https://datamaxiplus.com/).


### PR DESCRIPTION
Closes #110

## Summary
- `Cargo.toml`: append `[package.metadata.docs.rs]` with `all-features = true` and `rustdoc-args = ["--cfg", "docsrs"]`, appended at end of file only.
- `src/lib.rs`: `#![cfg_attr(docsrs, feature(doc_cfg))]` as first inner attribute (inert on stable).
- `src/api.rs`: `#[cfg_attr(docsrs, doc(cfg(feature = "...")))]` on `pub mod blocking` and on `impl futures_core::Stream for Paginator<T>`. Private `pending` field and `tracing` cfg (only gates internal instrumentation, no public item) left untouched.

Scope: only `Cargo.toml`, `src/lib.rs`, `src/api.rs` touched. `src/generated.rs` NOT touched (code-generated, DO NOT EDIT) — see note below.

## Verification

`cargo build --all-features` (stable) — pass
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.96s
```

`cargo +1.86.0 build --all-features` (MSRV) — pass
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.51s
```

`cargo doc --all-features --no-deps` (stable) — pass (13 pre-existing warnings, unrelated to this change: private intra-doc links + ambiguous `Error` link, all predate this diff)
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.57s
Generated .../target/doc/datamaxi/index.html
```

`cargo clippy --all-targets --all-features -- -D warnings` — pass, no warnings
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.26s
```

`cargo test --doc --all-features` — pass, 6/6, 0 ignored
```
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo test --all-features` (includes live suite against prod API, read-only GETs, expected per issue instructions) — pass
```
unit tests:        16 passed
generated_contract: 126 passed
live:               25 passed
pagination:         6 passed
wire_contract:      44 passed
doc-tests:          6 passed
```

### Nightly (not skipped — installed and verified)
```
rustup toolchain install nightly --profile minimal
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps
```
Succeeded (same 13 pre-existing warnings). Confirmed the badges actually render in the generated HTML:
- `target/doc/datamaxi/api/blocking/index.html` contains `Available on crate feature <code>blocking</code> only.`
- `target/doc/datamaxi/api/struct.Paginator.html` contains `Available on crate feature <code>stream</code> only.` on the `Stream` impl.

## Note
`src/generated.rs` has its own `#[cfg(feature = "blocking")] pub mod blocking` that needs the matching `doc(cfg)` treatment, but that file is emitted by `emit_rust.py` in `Bisonai/datamaxi-codegen` and is marked DO NOT EDIT. Left a comment on #110 so it isn't forgotten; needs a codegen-side change.
