### PR TITLE
CI/lints: forbid(unsafe_code), missing_docs, cargo-deny, cargo-semver-checks

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,0 +1,30 @@
+# Supply-chain audit: runs `cargo deny check` against the RustSec advisory
+# database plus the license / bans / sources policy in `deny.toml`. The crate's
+# whole job is to make network calls, so a vulnerable transitive dependency is
+# a real risk worth catching in CI.
+#
+# Triggers on push to main and on every PR, matching rust.yml. Also runs on
+# changes to deny.toml itself and weekly, so newly-published advisories against
+# already-pinned dependencies surface even without a code change.
+
+name: cargo-deny
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories bans licenses sources

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,11 +1,16 @@
 # Guards against accidental SemVer violations: cargo-semver-checks diffs the
-# crate's public API against the version already published on crates.io and
-# fails if the change (added/removed/altered items) is larger than the version
-# bump allows. The crate went 0.3.3 -> 0.12.0 with no mechanical check that the
-# bumps matched the API changes; this adds one.
+# crate's public API against a baseline and fails if the change (added /
+# removed / altered items) is larger than the version bump allows. The crate
+# went 0.3.3 -> 0.12.0 with no mechanical check that the bumps matched the API
+# changes; this adds one.
 #
-# PR-only: the check is about reviewing an API change before it merges, and it
-# needs the published baseline to compare against.
+# The crate is distributed via git (not published to crates.io), so there is no
+# registry baseline to diff against. Instead we diff each PR's public API
+# against the PR's base commit via `baseline-rev`; `fetch-depth: 0` makes that
+# commit available in the checkout. The action derives the expected bump from
+# the version in Cargo.toml.
+#
+# PR-only: the check is about reviewing an API change before it merges.
 
 name: semver-checks
 
@@ -21,8 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+        with:
+          fetch-depth: 0
       - uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
+          baseline-rev: ${{ github.event.pull_request.base.sha }}
           feature-group: all-features

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,28 @@
+# Guards against accidental SemVer violations: cargo-semver-checks diffs the
+# crate's public API against the version already published on crates.io and
+# fails if the change (added/removed/altered items) is larger than the version
+# bump allows. The crate went 0.3.3 -> 0.12.0 with no mechanical check that the
+# bumps matched the API changes; this adds one.
+#
+# PR-only: the check is about reviewing an API change before it merges, and it
+# needs the published baseline to compare against.
+
+name: semver-checks
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  semver-checks:
+    name: semver-checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          feature-group: all-features

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,51 @@
+# cargo-deny configuration — supply-chain checks for the datamaxi crate.
+# Run locally with `cargo deny check`; enforced in CI (.github/workflows/deny.yml).
+# Schema targets cargo-deny 0.16+ (the version cargo-deny-action@v2 ships).
+
+# ── Security advisories ──────────────────────────────────────────────────────
+# Checks dependencies against the RustSec advisory database. In cargo-deny
+# 0.16+ vulnerabilities / unmaintained / unsound / notice always error unless
+# explicitly listed in `ignore`, so there are no per-severity knobs here.
+[advisories]
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# Refuse yanked crates.
+yanked = "deny"
+# Advisory IDs to ignore, with a justification comment each. Keep empty.
+ignore = []
+
+# ── Licenses ─────────────────────────────────────────────────────────────────
+# Allow-list of SPDX identifiers. This set covers every license currently in
+# the dependency tree (all permissive / weak-copyleft). A new dependency under
+# a license not listed here fails CI on purpose — add it deliberately.
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Zlib",
+    "BSL-1.0",
+    "MPL-2.0",
+    "CDLA-Permissive-2.0",
+]
+confidence-threshold = 0.8
+exceptions = []
+
+# ── Banned / duplicate crates ────────────────────────────────────────────────
+[bans]
+# Duplicate versions of a crate are common in transitive trees and shouldn't
+# fail the build; surface them as warnings instead.
+multiple-versions = "warn"
+# No dependency should use a `*` version requirement.
+wildcards = "deny"
+allow = []
+deny = []
+
+# ── Sources ──────────────────────────────────────────────────────────────────
+# Every dependency must come from crates.io; no unknown registries or git deps.
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
 //! # DataMaxi+ Rust SDK
 //!
 //! This is the official implementation of Rust SDK for [DataMaxi+](https://datamaxiplus.com/).
@@ -91,7 +93,7 @@ pub mod api;
 // compatibility. The lint allows reflect the generator's unconditional imports
 // and its `new()`-only option constructors.
 #[doc(hidden)]
-#[allow(unused_imports, clippy::new_without_default)]
+#[allow(unused_imports, clippy::new_without_default, missing_docs)]
 pub mod generated;
 
 /// Typed wrappers for every REST endpoint on the data API — the canonical


### PR DESCRIPTION
Part of #116 — the **Lints / CI hygiene** section. Ticks these boxes:

- [x] Add `#![forbid(unsafe_code)]`
- [x] Add `#![warn(missing_docs)]`
- [x] Add `cargo-deny` (or `cargo-audit`) to CI
- [x] Add `cargo-semver-checks` to CI

Not in this PR: the API/runtime, naming, and other #116 items.

## What changed

**`src/lib.rs`**
- `#![forbid(unsafe_code)]` — the crate has no `unsafe`; make it a guarantee. Build passes.
- `#![warn(missing_docs)]` at the crate root. The hand-written code (`src/api.rs`, `src/lib.rs`) already fully satisfies it — zero new warnings.
- Added `missing_docs` to the existing `#[allow(...)]` on `pub mod generated`. `src/generated.rs` is produced by the external `datamaxi-codegen` tool (DO NOT EDIT) and its `Options` builder methods carry no doc comments, so a crate-wide `missing_docs` would flood warnings from generated code. Exempting only that module keeps generated code from blocking CI while holding hand-written code to the standard. Tracked for a real fix (emit docs in codegen) in #124, after which the exemption can be removed.

**`deny.toml` + `.github/workflows/deny.yml`** — `cargo deny check advisories bans licenses sources` on push/PR and weekly. The crate's whole job is network calls and nothing checked the RustSec advisory DB. License allow-list covers every license currently in the dependency tree.

**`.github/workflows/semver.yml`** — `cargo-semver-checks` on PRs. The crate isn't published to crates.io (it ships via git), so there's no registry baseline; the job diffs each PR's public API against the PR base commit (`baseline-rev`, `fetch-depth: 0`). The crate went 0.3.3 → 0.12.0 with no mechanical SemVer check.

## Test plan

Ran locally (Rust stable, `--all-features`):
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — 34 unit + 5 doc-tests pass
- `cargo build` / `cargo build --all-features` — no `missing_docs` warnings; `forbid(unsafe_code)` compiles
- `cargo doc --no-deps` — no new warnings (pre-existing broken-intra-doc-link warnings in `api.rs` are unrelated to this PR and present on `main`)

`cargo-deny` / `cargo-semver-checks` aren't installed locally, so those YAMLs are validated by inspection: action inputs checked against each action's `action.yml` (`EmbarkStudios/cargo-deny-action@v2` `command`; `obi1kenobi/cargo-semver-checks-action@v2` `baseline-rev` / `feature-group`), `deny.toml` validated as TOML and written to the cargo-deny 0.16+ schema, and the license allow-list derived from `cargo metadata` over the actual tree. They will first execute in CI on this PR.

## Known failures / caveats

- First `semver-checks` run compares against the base commit, which equals `main`; this PR makes no public API change, so it should pass.