### PR TITLE
Naming: disambiguate the two blocking modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,19 @@ candle
     .await?;
 ```
 
-With the `blocking` feature the same calls are synchronous (no `.await`), via
-`datamaxi::blocking::CexCandle` and `datamaxi::api::blocking`.
+With the `blocking` feature the same calls are synchronous (no `.await`).
+Everything the sync API needs lives under the single `datamaxi::blocking`
+module — `use datamaxi::blocking::{Client, CexCandle};` — the blocking
+counterpart to the crate root:
+
+```rust,ignore
+use datamaxi::blocking::Client;
+use datamaxi::CexCandleOptions;
+
+let client = Client::new("my_api_key");
+let candle = client.cex_candle();
+candle.get("binance", "ETH-USDT", CexCandleOptions::new())?;
+```
 
 Data endpoints deserialize into typed response structs generated from the API
 spec: object responses into a struct (e.g. `candle.get(..)` → `CexCandleResponse`)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,9 @@
 //! ### CEX Candle
 //!
 //! The client is async by default (requires a runtime such as `tokio`). For a
-//! synchronous client, enable the `blocking` feature and use the mirrored
-//! wrappers under `datamaxi::blocking` with `datamaxi::api::blocking`.
+//! synchronous client, enable the `blocking` feature; everything the sync API
+//! needs then lives under the single `datamaxi::blocking` module, e.g.
+//! `use datamaxi::blocking::{Client, CexCandle};`.
 //!
 //! ```no_run
 //! use datamaxi::{
@@ -118,6 +119,39 @@ pub use generated::*;
 /// write `datamaxi::Client` / `datamaxi::ClientBuilder`. Endpoint groups hang
 /// off the client via generated accessors, e.g. `client.cex_candle()`.
 pub use api::{Client, ClientBuilder};
+
+#[cfg(feature = "blocking")]
+#[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
+pub mod blocking {
+    //! Synchronous entry point for the SDK (feature `blocking`) — the blocking
+    //! counterpart to the crate root.
+    //!
+    //! This one module gathers everything the sync API needs: the [`Client`] /
+    //! [`ClientBuilder`] (blocking equivalents of the crate-root
+    //! [`crate::Client`] / [`crate::ClientBuilder`]), the [`Paginator`], and the
+    //! synchronous endpoint-wrapper types (`CexCandle`, `Announcements`, …) that
+    //! mirror the ones re-exported at the crate root. Prefer the single import
+    //! path `use datamaxi::blocking::{Client, CexCandle};` over combining
+    //! [`crate::api::blocking`] with the crate root.
+    //!
+    //! The [`Client`] / [`ClientBuilder`] / [`Paginator`] here are re-exports of
+    //! the same types in [`crate::api::blocking`], so those longer paths keep
+    //! working unchanged.
+    //!
+    //! ```no_run
+    //! use datamaxi::blocking::Client;
+    //! use datamaxi::CexCandleOptions;
+    //!
+    //! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+    //! let client = Client::new("YOUR_API_KEY");
+    //! let candle = client.cex_candle();
+    //! let _ = candle.get("binance", "BTC-USDT", CexCandleOptions::new())?;
+    //! # Ok(())
+    //! # }
+    //! ```
+    pub use crate::api::blocking::{Client, ClientBuilder, Paginator};
+    pub use crate::generated::blocking::*;
+}
 
 /// Re-exported so callers can name the exact `reqwest::Client` /
 /// `reqwest::blocking::Client` type expected by


### PR DESCRIPTION
Part of #116 — the "two different `blocking` modules" item.

## Problem
`pub use generated::*` re-exports `generated::blocking` (sync endpoint wrappers) as `datamaxi::blocking`, sitting next to the unrelated hand-written `datamaxi::api::blocking` (`Client`/`ClientBuilder`/`Paginator`). The docs had to keep telling sync users to combine **both** paths, e.g. "`datamaxi::blocking::CexCandle` **and** `datamaxi::api::blocking`".

## Approach chosen
Make `datamaxi::blocking` a **single, unified sync entry point** rather than trying to rename anything.

An explicit `pub mod blocking` in `lib.rs` re-exports, in one place:
- `Client` / `ClientBuilder` / `Paginator` from `api::blocking`, and
- the generated sync endpoint wrappers (`pub use crate::generated::blocking::*`).

The explicit module **shadows** the glob-imported `generated::blocking` (an item beats a glob binding of the same name — no conflict). This mirrors the async crate root, which already holds `Client` + the endpoint wrappers together, so sync users now write one import: `use datamaxi::blocking::{Client, CexCandle};`.

Only the hand-written side is touched. `generated.rs` (DO NOT EDIT) is untouched.

## Why not the alternatives
- **Rename `api::blocking`** — only the hand-written side is renameable, so a rename can't remove the *other* `blocking` name; it would just add churn/breakage without fixing the core "need both" confusion.
- **Rename `generated::blocking`** — requires the upstream `datamaxi-codegen` tool; out of scope here.
- **Narrow/drop `pub use generated::*`** — too breaking; it is the crate's canonical type surface (every `datamaxi::CexCandleResponse` etc.). Kept as-is. The residual "~200 names in the crate root" concern is codegen-side and filed separately (see below).

## Breaking?
**No.** Purely additive. Every prior path still resolves:
- `datamaxi::blocking::CexCandle` ✓ (now via the unified module)
- `datamaxi::api::blocking::Client` ✓ (unchanged home; also newly reachable as `datamaxi::blocking::Client`)

`api::blocking` becomes the implementation home that `datamaxi::blocking` re-exports — exactly the `api::Client` → `datamaxi::Client` relationship that already exists on the async side.

## Version implication
New public API surface (a new re-export path) ⇒ **minor bump** (0.12.0 → 0.13.0) at next release. Following repo convention (additive PRs #91/#106/#108/#119 didn't bump `Cargo.toml` themselves), this PR does not touch the version.

## Follow-up
Filed a `claude-found` codegen issue for the residual "~200 generated names in the crate root" concern (link added as a comment).

## Test plan
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean; also default-feature clippy clean
- `cargo test --all-features` — 44 unit + 7 doctests pass (incl. new `datamaxi::blocking` doctest)
- `cargo doc --no-deps` (default and `--all-features`) — no new warnings vs. baseline (verified by diffing warning counts; the pre-existing `api.rs` intra-doc-link warnings are unrelated and untouched)
- Live tests skip without `DTMX_API_KEY` (expected)