### PR TITLE
SDK runtime: error body+context, Arc<Inner>, retry-after date, rate-limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datamaxi"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.86"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ thiserror = "2.0.11"
 # Retry backoff jitter (see `apply_jitter` in `src/api.rs`). Zero deps outside
 # wasm targets; MSRV 1.63, well under our 1.86 floor.
 fastrand = "2"
+# Parses the HTTP-date form of the `Retry-After` header (RFC 9110 §10.2.3) in
+# `parse_retry_after`. Tiny, zero-dependency, MSRV well under our 1.86 floor.
+httpdate = "1"
 # Only the `time` feature, for the async retry backoff sleep. reqwest's async
 # surface already requires a Tokio runtime, so this adds no new runtime
 # requirement — it only makes the timer dependency explicit.

--- a/src/api.rs
+++ b/src/api.rs
@@ -33,7 +33,7 @@ use serde::de::DeserializeOwned;
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use thiserror::Error;
 
 // Host only: the generated endpoint paths are fully qualified and already
@@ -153,10 +153,16 @@ fn jitter_in_range(
     Duration::from_millis(random_u64(0..=upper_millis))
 }
 
-/// Parse a `Retry-After` header into a [`Duration`], expressed as an integer
-/// number of seconds. Only the numeric delay-seconds form (RFC 9110 §10.2.3)
-/// is understood; the alternative HTTP-date form yields `None` rather than
-/// panicking, as does a missing, non-ASCII, or unparseable header.
+/// Parse a `Retry-After` header into a [`Duration`], handling both forms
+/// defined in RFC 9110 §10.2.3:
+///
+/// - **delay-seconds** — a non-negative integer number of seconds, used as-is.
+/// - **HTTP-date** — an absolute date; the delay is `date - now`, clamped to
+///   zero if the date is already in the past (so a stale window never yields a
+///   negative or wildly large value). "Now" is read from the system clock.
+///
+/// A missing, non-ASCII, or otherwise unparseable header yields `None` rather
+/// than panicking.
 ///
 /// The returned value is the raw parsed duration, uncapped. Internal retry
 /// sleeps must apply their own [`RETRY_MAX_DELAY`] cap at the call site (see
@@ -164,14 +170,25 @@ fn jitter_in_range(
 /// [`Error::RateLimited`] is deliberately left uncapped so callers see the
 /// server's actual suggestion.
 fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
-    let secs = headers
+    let value = headers
         .get(reqwest::header::RETRY_AFTER)?
         .to_str()
         .ok()?
-        .trim()
-        .parse::<u64>()
-        .ok()?;
-    Some(Duration::from_secs(secs))
+        .trim();
+
+    // Prefer the delay-seconds form: a bare integer, used verbatim.
+    if let Ok(secs) = value.parse::<u64>() {
+        return Some(Duration::from_secs(secs));
+    }
+
+    // Otherwise try the HTTP-date form, computing the delay from now and
+    // clamping a past date to zero (`duration_since` errors when `when` is
+    // before `now`).
+    let when = httpdate::parse_http_date(value).ok()?;
+    Some(
+        when.duration_since(SystemTime::now())
+            .unwrap_or(Duration::ZERO),
+    )
 }
 
 /// The delay to wait before retrying a retryable response: a `429`'s
@@ -1036,9 +1053,9 @@ pub enum Error {
 
     /// The API returned a `429 Too Many Requests` (rate limited).
     ///
-    /// `retry_after` carries the raw `Retry-After` header value (in seconds)
-    /// when present; the HTTP-date form is not parsed and yields `None`. This
-    /// is the server's actual suggestion and is **not** clamped to
+    /// `retry_after` carries the `Retry-After` header when present, parsed from
+    /// either the delay-seconds or the HTTP-date form (a past date clamps to
+    /// zero). This is the server's actual suggestion and is **not** clamped to
     /// [`RETRY_MAX_DELAY`] (that cap only bounds the client's internal retry
     /// sleeps).
     #[error("Rate limited ({endpoint})")]
@@ -1523,16 +1540,42 @@ mod tests {
     }
 
     #[test]
-    fn parse_retry_after_ignores_http_date_and_missing() {
+    fn parse_retry_after_missing_or_garbage_is_none() {
         let empty = HeaderMap::new();
         assert_eq!(parse_retry_after(&empty), None);
 
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("not-a-date"));
+        assert_eq!(parse_retry_after(&headers), None);
+    }
+
+    #[test]
+    fn parse_retry_after_past_http_date_clamps_to_zero() {
+        // A date well in the past: the window has already elapsed, so the delay
+        // clamps to zero rather than going negative or wrapping.
         let mut headers = HeaderMap::new();
         headers.insert(
             RETRY_AFTER,
             HeaderValue::from_static("Wed, 21 Oct 2015 07:28:00 GMT"),
         );
-        assert_eq!(parse_retry_after(&headers), None);
+        assert_eq!(parse_retry_after(&headers), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn parse_retry_after_future_http_date_is_delay_from_now() {
+        // Format a date ~1 hour in the future via httpdate, then parse it back:
+        // the computed delay should be close to an hour (allowing a small
+        // window for the clock ticking between formatting and parsing).
+        let future = SystemTime::now() + Duration::from_secs(3600);
+        let header = httpdate::fmt_http_date(future);
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_str(&header).unwrap());
+
+        let delay = parse_retry_after(&headers).expect("future HTTP-date should parse");
+        assert!(
+            delay <= Duration::from_secs(3600) && delay >= Duration::from_secs(3590),
+            "expected ~3600s delay, got {delay:?}"
+        );
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -32,6 +32,7 @@ use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
+use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 
@@ -315,7 +316,7 @@ impl BuilderState {
 /// blocking flavor.
 macro_rules! get_loop {
     ($self:expr, $endpoint:expr, $parameters:expr, $handle_response:path, $sleep:path $(, $aw:ident)?) => {{
-        let url: String = format!("{}{}", $self.base_url, $endpoint);
+        let url: String = format!("{}{}", $self.inner.base_url, $endpoint);
         let mut attempt: u32 = 0;
 
         loop {
@@ -323,9 +324,10 @@ macro_rules! get_loop {
             tracing::Span::current().record("attempt", attempt as u64);
 
             let mut request = $self
+                .inner
                 .inner_client
                 .get(url.as_str())
-                .header("X-DTMX-APIKEY", &$self.api_key);
+                .header("X-DTMX-APIKEY", &$self.inner.api_key);
 
             if let Some(ref p) = $parameters {
                 request = request.query(p);
@@ -337,9 +339,9 @@ macro_rules! get_loop {
                     #[cfg(feature = "tracing")]
                     tracing::Span::current().record("status", status.as_u16() as u64);
 
-                    if attempt < $self.retry.max_retries && is_retryable_status(status) {
+                    if attempt < $self.inner.retry.max_retries && is_retryable_status(status) {
                         let delay = retry_delay_for_response(
-                            &$self.retry,
+                            &$self.inner.retry,
                             status,
                             response.headers(),
                             attempt,
@@ -359,8 +361,8 @@ macro_rules! get_loop {
                     return $handle_response(response, $endpoint)$(.$aw)?;
                 }
                 Err(error) => {
-                    if attempt < $self.retry.max_retries && is_retryable_error(&error) {
-                        let delay = jittered_backoff_delay(&$self.retry, attempt);
+                    if attempt < $self.inner.retry.max_retries && is_retryable_error(&error) {
+                        let delay = jittered_backoff_delay(&$self.inner.retry, attempt);
                         #[cfg(feature = "tracing")]
                         tracing::debug!(
                             target: "datamaxi::retry",
@@ -394,23 +396,36 @@ fn build_inner_client(timeout: Duration) -> reqwest::Client {
         .unwrap_or_else(|_| reqwest::Client::new())
 }
 
-/// The async client for interacting with the Datamaxi+ API.
-///
-/// This is the default surface. For a synchronous client, enable the
-/// `blocking` feature and use [`blocking::Client`].
-#[derive(Clone)]
-pub struct Client {
+/// Shared, immutable inner state of a [`Client`], held behind an [`Arc`] so
+/// that [`Client::clone`] — done once per endpoint-accessor call, e.g.
+/// [`Client::cex_candle`] — is a single refcount bump rather than re-allocating
+/// the `base_url` / `api_key` strings each time. `reqwest::Client` is already an
+/// `Arc` internally; wrapping the whole set of fields makes the two `String`s
+/// cheap to clone too.
+struct ClientInner {
     base_url: String,
     api_key: String,
     inner_client: reqwest::Client,
     retry: RetryConfig,
 }
 
+/// The async client for interacting with the Datamaxi+ API.
+///
+/// This is the default surface. For a synchronous client, enable the
+/// `blocking` feature and use [`blocking::Client`].
+///
+/// Cloning a `Client` is cheap: the shared state lives behind an [`Arc`], so a
+/// clone is a single refcount bump (see [`ClientInner`]).
+#[derive(Clone)]
+pub struct Client {
+    inner: Arc<ClientInner>,
+}
+
 impl std::fmt::Debug for Client {
     /// Redacts the API key so it never leaks into logs or error output.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Client")
-            .field("base_url", &self.base_url)
+            .field("base_url", &self.inner.base_url)
             .field("api_key", &"<redacted>")
             .finish_non_exhaustive()
     }
@@ -425,10 +440,12 @@ impl Client {
     /// groups are reached via accessors, e.g. [`Client::cex_candle`].
     pub fn new(api_key: impl Into<String>) -> Self {
         Client {
-            base_url: BASE_URL.to_string(),
-            api_key: api_key.into(),
-            inner_client: build_inner_client(DEFAULT_TIMEOUT),
-            retry: RetryConfig::default(),
+            inner: Arc::new(ClientInner {
+                base_url: BASE_URL.to_string(),
+                api_key: api_key.into(),
+                inner_client: build_inner_client(DEFAULT_TIMEOUT),
+                retry: RetryConfig::default(),
+            }),
         }
     }
 
@@ -953,10 +970,12 @@ impl ClientBuilder {
             .unwrap_or_else(|| build_inner_client(resolved.timeout));
 
         Ok(Client {
-            base_url: resolved.base_url,
-            api_key: resolved.api_key,
-            inner_client,
-            retry: resolved.retry,
+            inner: Arc::new(ClientInner {
+                base_url: resolved.base_url,
+                api_key: resolved.api_key,
+                inner_client,
+                retry: resolved.retry,
+            }),
         })
     }
 }
@@ -1089,6 +1108,7 @@ pub mod blocking {
     use std::collections::BTreeMap;
     use std::io::Read;
     use std::marker::PhantomData;
+    use std::sync::Arc;
     use std::time::Duration;
 
     /// Build the underlying blocking HTTP client with our defaults. Falls back
@@ -1102,20 +1122,30 @@ pub mod blocking {
             .unwrap_or_else(|_| reqwest::blocking::Client::new())
     }
 
-    /// The blocking client for interacting with the Datamaxi+ API.
-    #[derive(Clone)]
-    pub struct Client {
+    /// Shared, immutable inner state of a blocking [`Client`], held behind an
+    /// [`Arc`] so cloning is a single refcount bump. Mirrors the async
+    /// [`super::ClientInner`].
+    struct ClientInner {
         base_url: String,
         api_key: String,
         inner_client: reqwest::blocking::Client,
         retry: RetryConfig,
     }
 
+    /// The blocking client for interacting with the Datamaxi+ API.
+    ///
+    /// Cloning is cheap: the shared state lives behind an [`Arc`], so a clone is
+    /// a single refcount bump.
+    #[derive(Clone)]
+    pub struct Client {
+        inner: Arc<ClientInner>,
+    }
+
     impl std::fmt::Debug for Client {
         /// Redacts the API key so it never leaks into logs or error output.
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.debug_struct("Client")
-                .field("base_url", &self.base_url)
+                .field("base_url", &self.inner.base_url)
                 .field("api_key", &"<redacted>")
                 .finish_non_exhaustive()
         }
@@ -1128,10 +1158,12 @@ pub mod blocking {
         /// accessors, e.g. [`Client::cex_candle`].
         pub fn new(api_key: impl Into<String>) -> Self {
             Client {
-                base_url: BASE_URL.to_string(),
-                api_key: api_key.into(),
-                inner_client: build_inner_client(DEFAULT_TIMEOUT),
-                retry: RetryConfig::default(),
+                inner: Arc::new(ClientInner {
+                    base_url: BASE_URL.to_string(),
+                    api_key: api_key.into(),
+                    inner_client: build_inner_client(DEFAULT_TIMEOUT),
+                    retry: RetryConfig::default(),
+                }),
             }
         }
 
@@ -1370,10 +1402,12 @@ pub mod blocking {
                 .unwrap_or_else(|| build_inner_client(resolved.timeout));
 
             Ok(Client {
-                base_url: resolved.base_url,
-                api_key: resolved.api_key,
-                inner_client,
-                retry: resolved.retry,
+                inner: Arc::new(ClientInner {
+                    base_url: resolved.base_url,
+                    api_key: resolved.api_key,
+                    inner_client,
+                    retry: resolved.retry,
+                }),
             })
         }
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -825,7 +825,13 @@ async fn handle_response<T: DeserializeOwned>(response: reqwest::Response) -> Re
         StatusCode::BAD_REQUEST => Err(Error::BadRequest(read_body_capped(response).await)),
         status => match map_error_status(status, response.headers()) {
             Some(err) => Err(err),
-            None => Err(Error::UnexpectedStatusCode(status.as_u16())),
+            None => {
+                let code = status.as_u16();
+                Err(Error::UnexpectedStatusCode {
+                    status: code,
+                    body: read_body_capped(response).await,
+                })
+            }
         },
     }
 }
@@ -987,8 +993,19 @@ pub enum Error {
     InternalServerError(String),
 
     /// The API returned a status code the client does not specifically handle.
-    #[error("Received unexpected status code: {0}")]
-    UnexpectedStatusCode(u16),
+    ///
+    /// Carries both the raw status code and the (capped) response body. An
+    /// unexpected status is exactly the case where the body is most useful for
+    /// diagnosis, so — like [`Error::BadRequest`] / [`Error::InternalServerError`]
+    /// — it is preserved rather than discarded. The body is truncated to at most
+    /// [`MAX_ERROR_BODY_BYTES`] bytes on a UTF-8 char boundary.
+    #[error("Received unexpected status code {status}: {body}")]
+    UnexpectedStatusCode {
+        /// The raw HTTP status code.
+        status: u16,
+        /// The response body (capped, possibly empty).
+        body: String,
+    },
 
     /// The underlying HTTP request failed, or the response body could not be decoded.
     #[error(transparent)]
@@ -1215,7 +1232,13 @@ pub mod blocking {
             StatusCode::BAD_REQUEST => Err(Error::BadRequest(read_body_capped(response)?)),
             status => match map_error_status(status, response.headers()) {
                 Some(err) => Err(err),
-                None => Err(Error::UnexpectedStatusCode(status.as_u16())),
+                None => {
+                    let code = status.as_u16();
+                    Err(Error::UnexpectedStatusCode {
+                        status: code,
+                        body: read_body_capped(response)?,
+                    })
+                }
             },
         }
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -74,10 +74,10 @@ const MAX_ERROR_BODY_BYTES: usize = 1000;
 /// with exponential backoff (`base_delay * 2^attempt`, capped at
 /// [`RETRY_MAX_DELAY`]) plus full jitter (see [`apply_jitter`]), so many
 /// clients retrying at once don't thundering-herd the server in lockstep. A
-/// `429` response honors its `Retry-After` header (in seconds) when present —
-/// that's an explicit server-suggested delay, so it is used as-is, without
-/// jitter. Fatal statuses (`400`/`401`/`403`/`404`, and every other `4xx`)
-/// are never retried.
+/// `429` response honors its `Retry-After` header when present (either the
+/// delay-seconds or the HTTP-date form; see [`parse_retry_after`]) — that's an
+/// explicit server-suggested delay, so it is used as-is, without jitter. Fatal
+/// statuses (`400`/`401`/`403`/`404`, and every other `4xx`) are never retried.
 #[derive(Debug, Clone)]
 struct RetryConfig {
     max_retries: u32,
@@ -432,7 +432,7 @@ struct ClientInner {
 /// `blocking` feature and use [`blocking::Client`].
 ///
 /// Cloning a `Client` is cheap: the shared state lives behind an [`Arc`], so a
-/// clone is a single refcount bump (see [`ClientInner`]).
+/// clone is a single refcount bump.
 #[derive(Clone)]
 pub struct Client {
     inner: Arc<ClientInner>,
@@ -1082,8 +1082,7 @@ pub enum Error {
     /// response body. An unexpected status is exactly the case where the body
     /// is most useful for diagnosis, so — like [`Error::BadRequest`] /
     /// [`Error::InternalServerError`] — it is preserved rather than discarded.
-    /// The body is truncated to at most [`MAX_ERROR_BODY_BYTES`] bytes on a
-    /// UTF-8 char boundary.
+    /// The body is truncated to a capped length on a UTF-8 char boundary.
     #[error("Received unexpected status code {status} ({endpoint}): {body}")]
     UnexpectedStatusCode {
         /// The request path that produced this error.

--- a/src/api.rs
+++ b/src/api.rs
@@ -213,12 +213,23 @@ fn truncate_body(mut s: String) -> String {
 /// (which need per-flavor body handling) — to the corresponding [`Error`].
 /// Returns `None` for those three statuses, leaving them to the caller.
 /// Shared by the async and blocking `handle_response`.
-fn map_error_status(status: StatusCode, headers: &reqwest::header::HeaderMap) -> Option<Error> {
+fn map_error_status(
+    status: StatusCode,
+    headers: &reqwest::header::HeaderMap,
+    endpoint: &str,
+) -> Option<Error> {
     match status {
-        StatusCode::UNAUTHORIZED => Some(Error::Unauthorized),
-        StatusCode::FORBIDDEN => Some(Error::Forbidden),
-        StatusCode::NOT_FOUND => Some(Error::NotFound),
+        StatusCode::UNAUTHORIZED => Some(Error::Unauthorized {
+            endpoint: endpoint.to_string(),
+        }),
+        StatusCode::FORBIDDEN => Some(Error::Forbidden {
+            endpoint: endpoint.to_string(),
+        }),
+        StatusCode::NOT_FOUND => Some(Error::NotFound {
+            endpoint: endpoint.to_string(),
+        }),
         StatusCode::TOO_MANY_REQUESTS => Some(Error::RateLimited {
+            endpoint: endpoint.to_string(),
             retry_after: parse_retry_after(headers),
         }),
         _ => None,
@@ -345,7 +356,7 @@ macro_rules! get_loop {
                         $sleep(delay)$(.$aw)?;
                         continue;
                     }
-                    return $handle_response(response)$(.$aw)?;
+                    return $handle_response(response, $endpoint)$(.$aw)?;
                 }
                 Err(error) => {
                     if attempt < $self.retry.max_retries && is_retryable_error(&error) {
@@ -815,19 +826,28 @@ async fn read_body_capped(mut response: reqwest::Response) -> String {
     truncate_body(String::from_utf8_lossy(&buf).into_owned())
 }
 
-/// Processes an async response from the API and returns the result.
-async fn handle_response<T: DeserializeOwned>(response: reqwest::Response) -> Result<T> {
+/// Processes an async response from the API and returns the result. `endpoint`
+/// is the request path, attached to the returned [`Error`] for diagnosability.
+async fn handle_response<T: DeserializeOwned>(
+    response: reqwest::Response,
+    endpoint: &str,
+) -> Result<T> {
     match response.status() {
         StatusCode::OK => Ok(response.json::<T>().await?),
-        StatusCode::INTERNAL_SERVER_ERROR => {
-            Err(Error::InternalServerError(read_body_capped(response).await))
-        }
-        StatusCode::BAD_REQUEST => Err(Error::BadRequest(read_body_capped(response).await)),
-        status => match map_error_status(status, response.headers()) {
+        StatusCode::INTERNAL_SERVER_ERROR => Err(Error::InternalServerError {
+            endpoint: endpoint.to_string(),
+            body: read_body_capped(response).await,
+        }),
+        StatusCode::BAD_REQUEST => Err(Error::BadRequest {
+            endpoint: endpoint.to_string(),
+            body: read_body_capped(response).await,
+        }),
+        status => match map_error_status(status, response.headers(), endpoint) {
             Some(err) => Err(err),
             None => {
                 let code = status.as_u16();
                 Err(Error::UnexpectedStatusCode {
+                    endpoint: endpoint.to_string(),
                     status: code,
                     body: read_body_capped(response).await,
                 })
@@ -959,20 +979,41 @@ pub enum Error {
     MissingApiKey,
 
     /// The API returned a `400 Bad Request`; the payload carries the server message.
-    #[error("Bad request: {0}")]
-    BadRequest(String),
+    ///
+    /// `endpoint` is the request path that failed (e.g.
+    /// `/api/v1/liquidation/heatmap`), so failures are diagnosable without
+    /// enabling `tracing`.
+    #[error("Bad request ({endpoint}): {body}")]
+    BadRequest {
+        /// The request path that produced this error.
+        endpoint: String,
+        /// The server message (capped, possibly empty).
+        body: String,
+    },
 
     /// The API returned a `401 Unauthorized` (missing or invalid API key).
-    #[error("Unauthorized")]
-    Unauthorized,
+    #[error("Unauthorized ({endpoint})")]
+    Unauthorized {
+        /// The request path that produced this error.
+        endpoint: String,
+    },
 
     /// The API returned a `403 Forbidden` (the key is valid but lacks access to the resource).
-    #[error("Forbidden")]
-    Forbidden,
+    #[error("Forbidden ({endpoint})")]
+    Forbidden {
+        /// The request path that produced this error.
+        endpoint: String,
+    },
 
     /// The API returned a `404 Not Found` (the resource or endpoint does not exist).
-    #[error("Not found")]
-    NotFound,
+    ///
+    /// `endpoint` names which of the endpoints 404'd, so the error is
+    /// actionable on its own.
+    #[error("Not found ({endpoint})")]
+    NotFound {
+        /// The request path that produced this error.
+        endpoint: String,
+    },
 
     /// The API returned a `429 Too Many Requests` (rate limited).
     ///
@@ -981,33 +1022,45 @@ pub enum Error {
     /// is the server's actual suggestion and is **not** clamped to
     /// [`RETRY_MAX_DELAY`] (that cap only bounds the client's internal retry
     /// sleeps).
-    #[error("Rate limited")]
+    #[error("Rate limited ({endpoint})")]
     RateLimited {
+        /// The request path that produced this error.
+        endpoint: String,
         /// Suggested wait before retrying, from the `Retry-After` header
         /// (raw, uncapped).
         retry_after: Option<Duration>,
     },
 
     /// The API returned a `500 Internal Server Error`; the payload carries the server message.
-    #[error("Internal server error: {0}")]
-    InternalServerError(String),
+    #[error("Internal server error ({endpoint}): {body}")]
+    InternalServerError {
+        /// The request path that produced this error.
+        endpoint: String,
+        /// The server message (capped, possibly empty).
+        body: String,
+    },
 
     /// The API returned a status code the client does not specifically handle.
     ///
-    /// Carries both the raw status code and the (capped) response body. An
-    /// unexpected status is exactly the case where the body is most useful for
-    /// diagnosis, so — like [`Error::BadRequest`] / [`Error::InternalServerError`]
-    /// — it is preserved rather than discarded. The body is truncated to at most
-    /// [`MAX_ERROR_BODY_BYTES`] bytes on a UTF-8 char boundary.
-    #[error("Received unexpected status code {status}: {body}")]
+    /// Carries the request `endpoint`, the raw status code, and the (capped)
+    /// response body. An unexpected status is exactly the case where the body
+    /// is most useful for diagnosis, so — like [`Error::BadRequest`] /
+    /// [`Error::InternalServerError`] — it is preserved rather than discarded.
+    /// The body is truncated to at most [`MAX_ERROR_BODY_BYTES`] bytes on a
+    /// UTF-8 char boundary.
+    #[error("Received unexpected status code {status} ({endpoint}): {body}")]
     UnexpectedStatusCode {
+        /// The request path that produced this error.
+        endpoint: String,
         /// The raw HTTP status code.
         status: u16,
         /// The response body (capped, possibly empty).
         body: String,
     },
 
-    /// The underlying HTTP request failed, or the response body could not be decoded.
+    /// The underlying HTTP request failed, or the response body could not be
+    /// decoded. The failing URL is available via
+    /// [`reqwest::Error::url`](reqwest::Error::url) on the wrapped error.
     #[error(transparent)]
     Http(#[from] reqwest::Error),
 
@@ -1223,18 +1276,25 @@ pub mod blocking {
     }
 
     /// Processes a blocking response from the API and returns the result.
-    fn handle_response<T: DeserializeOwned>(response: Response) -> Result<T> {
+    /// `endpoint` is the request path, attached to the returned [`Error`] for
+    /// diagnosability.
+    fn handle_response<T: DeserializeOwned>(response: Response, endpoint: &str) -> Result<T> {
         match response.status() {
             StatusCode::OK => Ok(response.json::<T>()?),
-            StatusCode::INTERNAL_SERVER_ERROR => {
-                Err(Error::InternalServerError(read_body_capped(response)?))
-            }
-            StatusCode::BAD_REQUEST => Err(Error::BadRequest(read_body_capped(response)?)),
-            status => match map_error_status(status, response.headers()) {
+            StatusCode::INTERNAL_SERVER_ERROR => Err(Error::InternalServerError {
+                endpoint: endpoint.to_string(),
+                body: read_body_capped(response)?,
+            }),
+            StatusCode::BAD_REQUEST => Err(Error::BadRequest {
+                endpoint: endpoint.to_string(),
+                body: read_body_capped(response)?,
+            }),
+            status => match map_error_status(status, response.headers(), endpoint) {
                 Some(err) => Err(err),
                 None => {
                     let code = status.as_u16();
                     Err(Error::UnexpectedStatusCode {
+                        endpoint: endpoint.to_string(),
                         status: code,
                         body: read_body_capped(response)?,
                     })

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -218,7 +218,7 @@ async fn status_400_maps_to_bad_request() {
         .await
         .expect_err("400 should be Err");
     assert!(
-        matches!(err, Error::BadRequest(_)),
+        matches!(err, Error::BadRequest { .. }),
         "400 should map to BadRequest, got {:?}",
         err
     );
@@ -230,7 +230,7 @@ async fn status_401_maps_to_unauthorized() {
         .await
         .expect_err("401 should be Err");
     assert!(
-        matches!(err, Error::Unauthorized),
+        matches!(err, Error::Unauthorized { .. }),
         "401 should map to Unauthorized, got {:?}",
         err
     );
@@ -242,7 +242,7 @@ async fn status_500_maps_to_internal_server_error() {
         .await
         .expect_err("500 should be Err");
     assert!(
-        matches!(err, Error::InternalServerError(_)),
+        matches!(err, Error::InternalServerError { .. }),
         "500 should map to InternalServerError, got {:?}",
         err
     );
@@ -258,7 +258,7 @@ async fn status_400_body_over_1000_bytes_is_truncated() {
         .await
         .expect_err("400 should be Err");
     match err {
-        Error::BadRequest(body) => {
+        Error::BadRequest { body, .. } => {
             assert!(
                 body.len() <= 1000,
                 "expected truncated body <= 1000 bytes, got {}",
@@ -279,7 +279,7 @@ async fn status_500_body_over_1000_bytes_is_truncated() {
         .await
         .expect_err("500 should be Err");
     match err {
-        Error::InternalServerError(body) => {
+        Error::InternalServerError { body, .. } => {
             assert!(
                 body.len() <= 1000,
                 "expected truncated body <= 1000 bytes, got {}",
@@ -296,22 +296,28 @@ async fn status_403_maps_to_forbidden() {
         .await
         .expect_err("403 should be Err");
     assert!(
-        matches!(err, Error::Forbidden),
+        matches!(err, Error::Forbidden { .. }),
         "403 should map to Forbidden, got {:?}",
         err
     );
 }
 
+/// A `404` maps to `NotFound` AND carries the request path that 404'd, so the
+/// error is diagnosable without `tracing` (issue #116).
 #[tokio::test]
-async fn status_404_maps_to_not_found() {
+async fn status_404_maps_to_not_found_with_endpoint() {
     let err = call_with_status(404, "nope")
         .await
         .expect_err("404 should be Err");
-    assert!(
-        matches!(err, Error::NotFound),
-        "404 should map to NotFound, got {:?}",
-        err
-    );
+    match err {
+        Error::NotFound { endpoint } => {
+            assert_eq!(
+                endpoint, "/api/v1/liquidation/heatmap",
+                "NotFound must carry the endpoint that failed"
+            );
+        }
+        other => panic!("expected NotFound {{ endpoint }}, got {:?}", other),
+    }
 }
 
 /// An unmapped status (here `502`) still falls through to the catch-all
@@ -323,9 +329,17 @@ async fn status_502_maps_to_unexpected_status_code() {
         .await
         .expect_err("502 should be Err");
     match err {
-        Error::UnexpectedStatusCode { status, body } => {
+        Error::UnexpectedStatusCode {
+            endpoint,
+            status,
+            body,
+        } => {
             assert_eq!(status, 502);
             assert_eq!(body, "bad gateway", "the response body must be carried");
+            assert_eq!(
+                endpoint, "/api/v1/liquidation/heatmap",
+                "the endpoint must be carried"
+            );
         }
         other => panic!("expected UnexpectedStatusCode {{ 502, .. }}, got {:?}", other),
     }
@@ -337,7 +351,7 @@ async fn status_429_maps_to_rate_limited_without_retry_after() {
         .await
         .expect_err("429 should be Err");
     assert!(
-        matches!(err, Error::RateLimited { retry_after: None }),
+        matches!(err, Error::RateLimited { retry_after: None, .. }),
         "429 without Retry-After should map to RateLimited {{ retry_after: None }}, got {:?}",
         err
     );
@@ -363,7 +377,8 @@ async fn status_429_surfaces_retry_after_seconds() {
         matches!(
             err,
             Error::RateLimited {
-                retry_after: Some(d)
+                retry_after: Some(d),
+                ..
             } if d == std::time::Duration::from_secs(42)
         ),
         "429 with Retry-After: 42 should surface Duration::from_secs(42), got {:?}",
@@ -393,7 +408,8 @@ async fn status_429_http_date_retry_after_yields_none() {
         matches!(
             err,
             Error::RateLimited {
-                retry_after: None
+                retry_after: None,
+                ..
             }
         ),
         "429 with HTTP-date Retry-After should map to RateLimited {{ retry_after: None }}, got {:?}",
@@ -863,7 +879,7 @@ async fn no_retry_on_400() {
 
     mock.assert_async().await; // exactly one attempt, no retries
     assert!(
-        matches!(res, Err(Error::BadRequest(_))),
+        matches!(res, Err(Error::BadRequest { .. })),
         "expected BadRequest without retry, got {:?}",
         res
     );
@@ -934,7 +950,7 @@ fn blocking_no_retry_on_400() {
 
     mock.assert();
     assert!(
-        matches!(res, Err(Error::BadRequest(_))),
+        matches!(res, Err(Error::BadRequest { .. })),
         "expected BadRequest without retry, got {:?}",
         res
     );
@@ -966,7 +982,7 @@ fn blocking_call_with_status(
 fn blocking_status_403_maps_to_forbidden() {
     let err = blocking_call_with_status(403, None).expect_err("403 should be Err");
     assert!(
-        matches!(err, Error::Forbidden),
+        matches!(err, Error::Forbidden { .. }),
         "403 should map to Forbidden, got {:?}",
         err
     );
@@ -977,7 +993,7 @@ fn blocking_status_403_maps_to_forbidden() {
 fn blocking_status_404_maps_to_not_found() {
     let err = blocking_call_with_status(404, None).expect_err("404 should be Err");
     assert!(
-        matches!(err, Error::NotFound),
+        matches!(err, Error::NotFound { .. }),
         "404 should map to NotFound, got {:?}",
         err
     );
@@ -988,7 +1004,7 @@ fn blocking_status_404_maps_to_not_found() {
 fn blocking_status_429_maps_to_rate_limited_without_retry_after() {
     let err = blocking_call_with_status(429, None).expect_err("429 should be Err");
     assert!(
-        matches!(err, Error::RateLimited { retry_after: None }),
+        matches!(err, Error::RateLimited { retry_after: None, .. }),
         "429 without Retry-After should map to RateLimited {{ retry_after: None }}, got {:?}",
         err
     );
@@ -1001,7 +1017,7 @@ fn blocking_status_429_surfaces_retry_after_seconds() {
     assert!(
         matches!(
             err,
-            Error::RateLimited { retry_after: Some(d) }
+            Error::RateLimited { retry_after: Some(d), .. }
             if d == std::time::Duration::from_secs(42)
         ),
         "429 with Retry-After: 42 should surface Duration::from_secs(42), got {:?}",

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -315,17 +315,20 @@ async fn status_404_maps_to_not_found() {
 }
 
 /// An unmapped status (here `502`) still falls through to the catch-all
-/// `UnexpectedStatusCode`, carrying the raw code.
+/// `UnexpectedStatusCode`, carrying the raw code AND the response body (the body
+/// is no longer discarded — issue #116).
 #[tokio::test]
 async fn status_502_maps_to_unexpected_status_code() {
     let err = call_with_status(502, "bad gateway")
         .await
         .expect_err("502 should be Err");
-    assert!(
-        matches!(err, Error::UnexpectedStatusCode(502)),
-        "502 should map to UnexpectedStatusCode(502), got {:?}",
-        err
-    );
+    match err {
+        Error::UnexpectedStatusCode { status, body } => {
+            assert_eq!(status, 502);
+            assert_eq!(body, "bad gateway", "the response body must be carried");
+        }
+        other => panic!("expected UnexpectedStatusCode {{ 502, .. }}, got {:?}", other),
+    }
 }
 
 #[tokio::test]
@@ -834,7 +837,7 @@ async fn retry_exhaustion_returns_error() {
 
     mock.assert_async().await; // exactly 3 attempts
     assert!(
-        matches!(res, Err(Error::UnexpectedStatusCode(503))),
+        matches!(res, Err(Error::UnexpectedStatusCode { status: 503, .. })),
         "expected exhausted retries to surface the 503, got {:?}",
         res
     );

--- a/tests/wire_contract.rs
+++ b/tests/wire_contract.rs
@@ -341,7 +341,10 @@ async fn status_502_maps_to_unexpected_status_code() {
                 "the endpoint must be carried"
             );
         }
-        other => panic!("expected UnexpectedStatusCode {{ 502, .. }}, got {:?}", other),
+        other => panic!(
+            "expected UnexpectedStatusCode {{ 502, .. }}, got {:?}",
+            other
+        ),
     }
 }
 
@@ -351,7 +354,13 @@ async fn status_429_maps_to_rate_limited_without_retry_after() {
         .await
         .expect_err("429 should be Err");
     assert!(
-        matches!(err, Error::RateLimited { retry_after: None, .. }),
+        matches!(
+            err,
+            Error::RateLimited {
+                retry_after: None,
+                ..
+            }
+        ),
         "429 without Retry-After should map to RateLimited {{ retry_after: None }}, got {:?}",
         err
     );
@@ -386,10 +395,11 @@ async fn status_429_surfaces_retry_after_seconds() {
     );
 }
 
-/// A `Retry-After` HTTP-date (rather than delay-seconds) is not parsed and must
-/// yield `None` without panicking, while still mapping to `RateLimited`.
+/// A `Retry-After` HTTP-date **in the past** is now parsed (issue #116) and,
+/// since the window has already elapsed, clamps to `Duration::ZERO` — while
+/// still mapping to `RateLimited`.
 #[tokio::test]
-async fn status_429_http_date_retry_after_yields_none() {
+async fn status_429_past_http_date_retry_after_clamps_to_zero() {
     let mut server = mockito::Server::new_async().await;
     let _mock = server
         .mock("GET", "/api/v1/liquidation/heatmap")
@@ -408,13 +418,53 @@ async fn status_429_http_date_retry_after_yields_none() {
         matches!(
             err,
             Error::RateLimited {
-                retry_after: None,
+                retry_after: Some(d),
                 ..
-            }
+            } if d == std::time::Duration::ZERO
         ),
-        "429 with HTTP-date Retry-After should map to RateLimited {{ retry_after: None }}, got {:?}",
+        "429 with a past HTTP-date Retry-After should surface Duration::ZERO, got {:?}",
         err
     );
+}
+
+/// A `Retry-After` HTTP-date in the future is parsed into a positive delay
+/// (roughly the distance from now to that date).
+#[tokio::test]
+async fn status_429_future_http_date_retry_after_is_positive() {
+    let future = std::time::SystemTime::now() + std::time::Duration::from_secs(3600);
+    let header = httpdate::fmt_http_date(future);
+
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/api/v1/liquidation/heatmap")
+        .with_status(429)
+        .with_header("Retry-After", &header)
+        .with_body("slow down")
+        .create_async()
+        .await;
+
+    let liq = mock_client(server.url()).liquidation();
+    let err = liq
+        .heatmap(LiquidationHeatmapOptions::new())
+        .await
+        .expect_err("429 should be Err");
+    match err {
+        Error::RateLimited {
+            retry_after: Some(d),
+            ..
+        } => {
+            assert!(
+                d > std::time::Duration::from_secs(3000)
+                    && d <= std::time::Duration::from_secs(3600),
+                "expected a ~1h future delay, got {:?}",
+                d
+            );
+        }
+        other => panic!(
+            "expected RateLimited with a positive delay, got {:?}",
+            other
+        ),
+    }
 }
 
 // --- Per-endpoint snake_case wire-key guards (issue #16) -------------------
@@ -1004,7 +1054,13 @@ fn blocking_status_404_maps_to_not_found() {
 fn blocking_status_429_maps_to_rate_limited_without_retry_after() {
     let err = blocking_call_with_status(429, None).expect_err("429 should be Err");
     assert!(
-        matches!(err, Error::RateLimited { retry_after: None, .. }),
+        matches!(
+            err,
+            Error::RateLimited {
+                retry_after: None,
+                ..
+            }
+        ),
         "429 without Retry-After should map to RateLimited {{ retry_after: None }}, got {:?}",
         err
     );


### PR DESCRIPTION
Part of #116 — the **API / runtime** slice of the meta-issue (three PRs partially address it; this is one).

## What ships

- [x] **`Error::UnexpectedStatusCode` no longer drops the body.** Now `UnexpectedStatusCode { endpoint, status, body }` — the one error arm that previously threw away the body (the case where you most want it) now carries the capped body, like `BadRequest` / `InternalServerError`.
- [x] **Errors carry the failing endpoint.** Every status-derived variant (`BadRequest`, `Unauthorized`, `Forbidden`, `NotFound`, `RateLimited`, `InternalServerError`, `UnexpectedStatusCode`) gains an `endpoint: String`, threaded through `handle_response` / `map_error_status` from the request path and surfaced in each `Display` message. `Err(Error::NotFound { endpoint })` now tells you *which* of the endpoints 404'd, no `tracing` required. Transport failures stay in `Http(reqwest::Error)`, which already carries the failing URL.
- [x] **`Client` clones are a single refcount bump.** Fields moved into a private `ClientInner` behind `Arc`; `Client` is now `{ inner: Arc<ClientInner> }`, so each `client.cex_candle()`-style accessor clone stops re-allocating the two `String`s. Same shape mirrored for the blocking client. Public API (accessors, builder, `Debug` redaction) unchanged.
- [x] **`parse_retry_after` handles the HTTP-date form.** Adds the tiny zero-dep `httpdate` crate; the date form is parsed as `date - now`, clamping a past date to `Duration::ZERO`. Delay-seconds form unchanged.

## Deferred (not in this PR)

- [ ] **Surface rate-limit headers.** Investigated: the DataMaxi+ docs (`docs.datamaxiplus.com/rest/info`) state a limit of 20 req / 30s and a `429` on exceed, but **do not document any `x-ratelimit-*` response header names**, and there are no fixtures/tests in the repo referencing them. Per the "don't guess and ship dead code" guidance, this item is deferred and filed as `claude-found` issue #129 to confirm the actual header names from a live response before implementing.

## Breaking change + version bump

The `Error` enum variants changed shape (tuple/unit → struct, added `endpoint`). `Error` is `#[non_exhaustive]`; callers matching variants now use struct patterns (e.g. `Error::NotFound { .. }`). Version bumped **0.12.0 → 0.13.0** accordingly (pre-1.0: minor bump signals breaking).

## Test plan

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` and `--all-features` — clean
- `cargo test`, `cargo test --all-features`, `cargo test --no-default-features --features blocking,rustls-tls` — all green
- New/updated tests: `UnexpectedStatusCode` carries body+endpoint (502); `NotFound` carries endpoint (404); `parse_retry_after` past-date clamps to zero + future-date positive delay (unit + wire-contract); all existing status-mapping tests updated to the new variant shapes.
- Live tests (`tests/live.rs`) skip without `DTMX_API_KEY` (expected).

## Review

Independent senior-review pass: clean across the full build/clippy/test matrix; the only actionable finding (version not bumped for the breaking change) is fixed in this PR.