### PR TITLE
Sync generated Rust with backend spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datamaxi"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.86"
 readme = "README.md"

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -1088,9 +1088,6 @@ pub struct TickerResponse {
     pub currency: String,
     pub data: TickerView,
     pub market: String,
-    /// Source is populated only when ?include_source=true; omitempty drops the key for default callers, preserving the pre-Phase-1 JSON byte shape (strict-decoder safe).
-    #[serde(default)]
-    pub src: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -4350,9 +4347,6 @@ impl Ticker {
         if let Some(v) = options.conversion_base {
             parameters.insert("conversion_base".to_string(), v.to_string());
         }
-        if let Some(v) = options.include_source {
-            parameters.insert("include_source".to_string(), v.to_string());
-        }
         self.client.get("/api/v1/ticker", Some(parameters)).await
     }
 
@@ -4386,8 +4380,6 @@ pub struct TickerOptions {
     pub currency: Option<TickerCurrency>,
     /// Specifies conversion base applied to price values (e.g. `USDT`)
     pub conversion_base: Option<TickerConversionBase>,
-    /// When true, include the frame's transport source (ws|rest) in the response. (e.g. `true`)
-    pub include_source: Option<bool>,
 }
 
 impl TickerOptions {
@@ -4395,7 +4387,6 @@ impl TickerOptions {
         TickerOptions {
             currency: None,
             conversion_base: None,
-            include_source: None,
         }
     }
 
@@ -4406,11 +4397,6 @@ impl TickerOptions {
 
     pub fn conversion_base(mut self, conversion_base: TickerConversionBase) -> Self {
         self.conversion_base = Some(conversion_base);
-        self
-    }
-
-    pub fn include_source(mut self, include_source: bool) -> Self {
-        self.include_source = Some(include_source);
         self
     }
 }
@@ -5659,9 +5645,6 @@ pub mod blocking {
             }
             if let Some(v) = options.conversion_base {
                 parameters.insert("conversion_base".to_string(), v.to_string());
-            }
-            if let Some(v) = options.include_source {
-                parameters.insert("include_source".to_string(), v.to_string());
             }
             self.client.get("/api/v1/ticker", Some(parameters))
         }

--- a/tests/generated_contract.rs
+++ b/tests/generated_contract.rs
@@ -2497,7 +2497,6 @@ fn contract_ticker_response() {
             "v": 1.5,
         },
         "market": "s",
-        "src": "s",
     });
     assert_roundtrip::<datamaxi::TickerResponse>(fixture);
 }
@@ -2523,7 +2522,6 @@ fn contract_ticker_response_missing_required() {
             "v": 1.5,
         },
         "market": "s",
-        "src": "s",
     });
     assert_missing_required::<datamaxi::TickerResponse>(fixture, "currency");
 }


### PR DESCRIPTION
Automated codegen sync from **datamaxi-codegen**.

The committed `src/generated.rs` and/or `tests/generated_contract.rs`
had drifted from the current `Bisonai/datamaxi-backend` OpenAPI spec.
This PR regenerates both via `make update-rust`.

`tests/generated_contract.rs` holds serde round-trip wire-contract
tests emitted from the same manifest as the structs, so a
rename/retype updates the struct and its test together — this sync PR
stays green instead of breaking on a hand-written per-field assertion.

Triggering codegen run:
https://github.com/Bisonai/datamaxi-codegen/actions/runs/29408527407

Do not edit `src/generated.rs` or `tests/generated_contract.rs` by
hand — both are generated. Re-run the codegen workflow to refresh.