### PR TITLE
refactor: rename generated blocking module -> sync_endpoints (#127)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1108,7 +1108,7 @@ pub enum Error {
 ///
 /// Mirrors the async [`Client`] with the same status-to-[`Error`] mapping, for
 /// scripts, notebooks, and other callers that don't run an async runtime. The
-/// generated endpoint wrappers under [`crate::generated::sync_endpoints`] use this.
+/// generated endpoint wrappers under [`crate::generated::sync`] use this.
 #[cfg(feature = "blocking")]
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 pub mod blocking {

--- a/src/api.rs
+++ b/src/api.rs
@@ -1108,7 +1108,7 @@ pub enum Error {
 ///
 /// Mirrors the async [`Client`] with the same status-to-[`Error`] mapping, for
 /// scripts, notebooks, and other callers that don't run an async runtime. The
-/// generated endpoint wrappers under [`crate::generated::blocking`] use this.
+/// generated endpoint wrappers under [`crate::generated::sync_endpoints`] use this.
 #[cfg(feature = "blocking")]
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 pub mod blocking {

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -4838,7 +4838,7 @@ impl Client {
 }
 
 #[cfg(feature = "blocking")]
-pub mod blocking {
+pub mod sync_endpoints {
     //! Synchronous mirror of the endpoint wrappers (feature `blocking`).
     //!
     //! Identical API to the async surface minus `async`/`.await`, backed by

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -4838,7 +4838,7 @@ impl Client {
 }
 
 #[cfg(feature = "blocking")]
-pub mod sync_endpoints {
+pub mod sync {
     //! Synchronous mirror of the endpoint wrappers (feature `blocking`).
     //!
     //! Identical API to the async surface minus `async`/`.await`, backed by

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub mod blocking {
     //! # }
     //! ```
     pub use crate::api::blocking::{Client, ClientBuilder, Paginator};
-    pub use crate::generated::sync_endpoints::*;
+    pub use crate::generated::sync::*;
 }
 
 /// Re-exported so callers can name the exact `reqwest::Client` /

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub mod blocking {
     //! # }
     //! ```
     pub use crate::api::blocking::{Client, ClientBuilder, Paginator};
-    pub use crate::generated::blocking::*;
+    pub use crate::generated::sync_endpoints::*;
 }
 
 /// Re-exported so callers can name the exact `reqwest::Client` /


### PR DESCRIPTION
Applied / companion half of a coordinated, two-repo change implementing **Option 3** of #127.

Codegen source-of-truth PR: Bisonai/datamaxi-codegen#112

## What
The generated synchronous mirror module was renamed `blocking` -> `sync` upstream (datamaxi-codegen; short name mirroring the async surface). This PR applies that rename here and points the unified public `datamaxi::blocking` module at it, so `datamaxi::blocking` no longer has to shadow a same-named glob-imported `generated::blocking`.

- `src/generated.rs`: sole `pub mod blocking {` -> `pub mod sync {` (exactly what the updated codegen now emits; the daily `make check-rust` drift-guard sees no drift). Feature gate `#[cfg(feature = "blocking")]` unchanged.
- `src/lib.rs`: `pub use crate::generated::blocking::*;` -> `...::sync::*;`. The hand-written public `pub mod blocking` keeps its name.
- `src/api.rs`: fixed the intra-doc link `[crate::generated::blocking]` -> `[crate::generated::sync]`. `crate::api::blocking` untouched.

## Public API
Unchanged — `datamaxi::blocking::{Client, ClientBuilder, Paginator, CexCandle, ...}` resolve exactly as before.

## Known minor wart (accepted / possible follow-up)
`pub use generated::*;` now glob-exports a new `datamaxi::sync` path alias (previously the same-named `blocking` was shadowed). It is feature-gated and harmless; fully removing it belongs to the larger types-module reorg (Option 2, out of scope here). Left as-is to keep this change minimal.

## Test plan
- `cargo build --all-features` clean.
- `cargo test --all-features` green (all binaries: unit + doc-tests, incl. the blocking doc-test).
- `cargo fmt --check` clean.

Closes #127